### PR TITLE
declutter homepage: form-only with nav links to About, FAQ

### DIFF
--- a/apps/cathedral/app/about/page.tsx
+++ b/apps/cathedral/app/about/page.tsx
@@ -43,7 +43,7 @@ export default function AboutPage() {
           </p>
         </section>
 
-        <section className="space-y-4 text-sm text-[var(--text-muted)] leading-relaxed">
+        <section id="how-it-works" className="space-y-4 text-sm text-[var(--text-muted)] leading-relaxed scroll-mt-8">
           <h2 className="text-lg text-[var(--text-primary)] font-medium">
             How It Works
           </h2>

--- a/apps/cathedral/app/faq/page.tsx
+++ b/apps/cathedral/app/faq/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Frequently Asked Questions",
+  description:
+    "Common questions about Digital Cathedral, military life insurance options, SGLI alternatives, and how our free coverage review works.",
+};
+
+const FAQS = [
+  {
+    q: "Is this the same as SGLI?",
+    a: "No. This is a review of additional or alternative life insurance options available outside standard military coverage. SGLI (Servicemembers' Group Life Insurance) is a separate program administered by the VA.",
+  },
+  {
+    q: "Is this affiliated with the military or government?",
+    a: "No. Digital Cathedral is independently operated and not affiliated with the U.S. Government, Department of Defense, or any branch of military service.",
+  },
+  {
+    q: "Is there any obligation to purchase?",
+    a: "No. Requesting a review simply connects you with a licensed professional to explore your options. There is no obligation, no pressure, and no cost for the consultation.",
+  },
+  {
+    q: "Are veterans eligible?",
+    a: "Yes. Many life insurance options are available for veterans, including those who have fully separated from service. Options vary by state and individual eligibility.",
+  },
+  {
+    q: "How long does the process take?",
+    a: "The form takes less than 60 seconds. After you submit, a licensed insurance professional will typically reach out within 1 business day.",
+  },
+  {
+    q: "What happens to my information?",
+    a: "Your information is securely stored and shared only with licensed insurance professionals who may contact you about coverage options. See our Privacy Policy for full details. You can request deletion of your data at any time under CCPA/CPRA.",
+  },
+  {
+    q: "Do you sell insurance?",
+    a: "No. Digital Cathedral is not an insurance company, agent, or broker. We do not sell insurance, provide quotes, or bind coverage. We connect consumers with licensed professionals.",
+  },
+  {
+    q: "Who will contact me?",
+    a: "A licensed insurance professional experienced in military-family coverage will review your information and reach out via phone or email.",
+  },
+];
+
+export default function FaqPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center px-4 py-12">
+      <article className="w-full max-w-2xl space-y-8">
+        <header>
+          <Link
+            href="/"
+            className="text-emerald-accent text-xs tracking-[0.2em] uppercase mb-6 inline-block hover:opacity-80 transition-opacity"
+          >
+            &larr; Back Home
+          </Link>
+          <h1 className="text-2xl sm:text-3xl font-light text-[var(--text-primary)] mb-2">
+            Frequently Asked Questions
+          </h1>
+          <p className="text-sm text-[var(--text-muted)]">
+            Common questions about our free coverage review service.
+          </p>
+        </header>
+
+        <div className="space-y-6">
+          {FAQS.map((item) => (
+            <div key={item.q} className="border-b border-navy-cathedral/8 pb-5">
+              <h2 className="text-sm font-medium text-[var(--text-primary)] mb-2">
+                {item.q}
+              </h2>
+              <p className="text-sm text-[var(--text-muted)] leading-relaxed">
+                {item.a}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="cathedral-surface p-6 text-center">
+          <p className="text-sm text-[var(--text-muted)] mb-4">
+            Have a question not answered here?
+          </p>
+          <a
+            href="mailto:privacy@digital-cathedral.app"
+            className="text-emerald-accent text-sm hover:underline"
+          >
+            Contact us
+          </a>
+        </div>
+
+        <div className="text-center pt-4">
+          <Link
+            href="/"
+            className="inline-block px-8 py-3 rounded-lg font-medium text-sm transition-all bg-emerald-accent text-white hover:bg-emerald-accent/90"
+          >
+            Start My Coverage Review
+          </Link>
+          <p className="text-xs text-[var(--text-muted)] mt-2">Takes less than 60 seconds.</p>
+        </div>
+
+        <footer className="pt-8 border-t border-emerald-accent/10 text-center">
+          <nav className="flex gap-4 justify-center mb-3">
+            <Link href="/about" className="text-emerald-accent/70 hover:text-emerald-accent text-xs">About</Link>
+            <Link href="/privacy" className="text-emerald-accent/70 hover:text-emerald-accent text-xs">Privacy Policy</Link>
+            <Link href="/terms" className="text-emerald-accent/70 hover:text-emerald-accent text-xs">Terms of Service</Link>
+          </nav>
+          <p className="text-xs text-[var(--text-muted)]">
+            &copy; {new Date().getFullYear()} Digital Cathedral. All rights reserved.
+          </p>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/apps/cathedral/app/page.tsx
+++ b/apps/cathedral/app/page.tsx
@@ -472,188 +472,32 @@ export default function HomePage() {
         </a>
       </div>
 
-      {/* Section 2: The Gap Most Don't Realize Exists */}
-      <section className="w-full max-w-2xl mt-20 px-4 text-center" aria-labelledby="gap-heading">
-        <h2 id="gap-heading" className="text-2xl md:text-3xl font-light text-[var(--text-primary)] mb-6">
-          Your Service Protects Others. But Is Your Family Fully Protected?
-        </h2>
-        <div className="text-sm text-[var(--text-muted)] leading-relaxed space-y-4 text-left max-w-xl mx-auto">
-          <p>
-            Many service members rely solely on SGLI or assume their coverage will always be enough.
-          </p>
-          <p>
-            But coverage limits, conversion timelines, and post-service changes can create unexpected gaps.
-          </p>
-          <p className="font-medium text-[var(--text-primary)]">Whether you&rsquo;re:</p>
-          <ul className="grid grid-cols-2 gap-2 text-[var(--text-primary)] text-sm">
-            {["Active Duty", "National Guard", "Reserve", "Transitioning out", "Fully separated"].map((item) => (
-              <li key={item} className="flex items-center gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-emerald-accent flex-shrink-0" aria-hidden="true" />
-                {item}
-              </li>
-            ))}
-          </ul>
-          <p>
-            It&rsquo;s important to understand what options exist beyond basic military coverage.
-          </p>
-          <p className="italic text-[var(--text-primary)]">
-            This isn&rsquo;t about replacing anything.<br />
-            It&rsquo;s about understanding your full protection picture.
-          </p>
-        </div>
-      </section>
-
-      {/* Section 3: Veteran-Founded. Mission-Driven. */}
-      <section className="w-full max-w-2xl mt-20 px-4" aria-labelledby="veteran-founded-heading">
-        <h2 id="veteran-founded-heading" className="text-2xl md:text-3xl font-light text-[var(--text-primary)] mb-6 text-center">
-          Founded by a Veteran. Dedicated to Serving Those Who Served.
-        </h2>
-
-        {/* Photo placeholder */}
-        <div className="w-32 h-32 mx-auto mb-6 rounded-full bg-soft-gray border-2 border-emerald-accent/20 flex items-center justify-center">
-          <svg className="w-12 h-12 text-[var(--text-muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
-          </svg>
-        </div>
-
-        <div className="text-sm text-[var(--text-muted)] leading-relaxed space-y-4 max-w-xl mx-auto">
-          <p>
-            As a veteran, I understand the responsibility that comes with wearing the uniform
-            — and the responsibility that continues after it comes off.
-          </p>
-          <p>
-            After serving, I saw how many military families weren&rsquo;t fully informed about
-            their life insurance options outside of standard military coverage.
-          </p>
-          <p className="text-[var(--text-primary)] font-medium">
-            This platform was created as a bridge.
-          </p>
-          <p>
-            When you request a review, we connect you with trusted, independent, licensed
-            insurance professionals who understand the unique needs of military families.
-          </p>
-          <p className="italic text-[var(--text-primary)]">
-            This is personal.<br />
-            Service doesn&rsquo;t end at separation — and neither should protection.
-          </p>
-          <p className="text-xs text-[var(--text-muted)] mt-4 pt-4 border-t border-navy-cathedral/8">
-            We are not affiliated with the U.S. Government or Department of Defense. We connect
-            individuals with independent, licensed insurance professionals.
-          </p>
-        </div>
-      </section>
-
-      {/* Section 4: How It Works */}
-      <section className="w-full max-w-2xl mt-20 px-4 text-center" aria-labelledby="how-it-works-heading">
-        <h2 id="how-it-works-heading" className="text-2xl md:text-3xl font-light text-[var(--text-primary)] mb-8">
-          Simple. Structured. Secure.
-        </h2>
-        <div className="grid md:grid-cols-3 gap-6">
-          {[
-            { step: "1", title: "Submit", desc: "Submit a short, secure form." },
-            { step: "2", title: "Connect", desc: "We connect you with a licensed professional experienced in military family coverage." },
-            { step: "3", title: "Review", desc: "Review your options and decide what\u2019s right for your family." },
-          ].map((item) => (
-            <div key={item.step} className="cathedral-surface p-6 text-center">
-              <div className="w-10 h-10 rounded-full bg-emerald-accent text-white flex items-center justify-center text-sm font-medium mx-auto mb-3">
-                {item.step}
-              </div>
-              <h3 className="text-sm font-medium text-[var(--text-primary)] mb-2">{item.title}</h3>
-              <p className="text-xs text-[var(--text-muted)] leading-relaxed">{item.desc}</p>
-            </div>
-          ))}
-        </div>
-        <p className="text-sm text-[var(--text-muted)] mt-6 italic">
-          No pressure. No obligation. Just clarity.
-        </p>
-      </section>
-
-      {/* Section 5: Who This Is For */}
-      <section className="w-full max-w-2xl mt-20 px-4 text-center" aria-labelledby="who-heading">
-        <h2 id="who-heading" className="text-2xl md:text-3xl font-light text-[var(--text-primary)] mb-3">
-          Serving Every Stage of Service.
-        </h2>
-        <p className="text-sm text-[var(--text-muted)] mb-8">This resource is built for:</p>
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-          {[
-            "Active Duty Service Members",
-            "National Guard",
-            "Reserve Members",
-            "Veterans",
-            "Military Families",
-            "Transitioning Service Members",
-          ].map((category) => (
-            <div key={category} className="cathedral-surface p-4 text-center">
-              <p className="text-sm text-[var(--text-primary)] font-medium">{category}</p>
-            </div>
-          ))}
-        </div>
-        <p className="text-sm text-[var(--text-primary)] mt-6 font-medium">
-          If you&rsquo;ve served — this is for you.
-        </p>
-      </section>
-
-      {/* Section 6: Frequently Asked Questions */}
-      <section className="w-full max-w-2xl mt-20 px-4" aria-labelledby="faq-heading">
-        <h2 id="faq-heading" className="text-2xl md:text-3xl font-light text-[var(--text-primary)] mb-8 text-center">
-          Frequently Asked Questions
-        </h2>
-        <div className="space-y-6 max-w-xl mx-auto">
-          {[
-            {
-              q: "Is this the same as SGLI?",
-              a: "No. This is a review of additional or alternative life insurance options available outside standard military coverage.",
-            },
-            {
-              q: "Is this affiliated with the military?",
-              a: "No. This platform is independently operated and not affiliated with the U.S. Government or Department of Defense.",
-            },
-            {
-              q: "Is there an obligation to purchase?",
-              a: "No. Requesting a review simply connects you with a licensed professional to explore your options.",
-            },
-            {
-              q: "Are veterans eligible?",
-              a: "Yes. Many options are available for veterans, including those who have separated from service.",
-            },
-          ].map((item) => (
-            <div key={item.q} className="border-b border-navy-cathedral/8 pb-4">
-              <h3 className="text-sm font-medium text-[var(--text-primary)] mb-2">{item.q}</h3>
-              <p className="text-sm text-[var(--text-muted)] leading-relaxed">{item.a}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Section 7: Final Call to Action */}
-      <section className="w-full max-w-2xl mt-20 px-4 text-center" aria-labelledby="final-cta-heading">
-        <h2 id="final-cta-heading" className="text-2xl md:text-3xl font-light text-[var(--text-primary)] mb-4">
-          Your Service Meant Something. So Does Your Family&rsquo;s Security.
-        </h2>
-        <p className="text-sm text-[var(--text-muted)] leading-relaxed mb-2">
-          You&rsquo;ve protected others.
-        </p>
-        <p className="text-sm text-[var(--text-muted)] leading-relaxed mb-8">
-          Now let&rsquo;s make sure your family is protected too.
-        </p>
-        <button
-          type="button"
-          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-          className="px-8 py-3 rounded-lg font-medium text-sm transition-all bg-emerald-accent text-white hover:bg-emerald-accent/90 hover:shadow-[0_0_30px_rgba(45,134,89,0.15)]"
-        >
-          Start My Coverage Review
-        </button>
-        <p className="text-xs text-[var(--text-muted)] mt-3">Takes less than 60 seconds.</p>
-      </section>
-
-      {/* Trust Signals — Social Proof & How It Works */}
-      <div className="w-full flex justify-center mt-16 px-4">
+      {/* Trust Signals */}
+      <div className="w-full flex justify-center mt-10 px-4">
         <TrustSignals />
       </div>
 
+      {/* Quick Links */}
+      <nav className="w-full max-w-lg mt-10 grid grid-cols-3 gap-3" aria-label="Learn more">
+        <a href="/about" className="cathedral-surface p-4 text-center hover:border-emerald-accent/30 transition-all group">
+          <p className="text-sm font-medium text-[var(--text-primary)] group-hover:text-emerald-accent transition-colors">About Us</p>
+          <p className="text-xs text-[var(--text-muted)] mt-1">Our mission &amp; story</p>
+        </a>
+        <a href="/faq" className="cathedral-surface p-4 text-center hover:border-emerald-accent/30 transition-all group">
+          <p className="text-sm font-medium text-[var(--text-primary)] group-hover:text-emerald-accent transition-colors">FAQ</p>
+          <p className="text-xs text-[var(--text-muted)] mt-1">Common questions</p>
+        </a>
+        <a href="/about#how-it-works" className="cathedral-surface p-4 text-center hover:border-emerald-accent/30 transition-all group">
+          <p className="text-sm font-medium text-[var(--text-primary)] group-hover:text-emerald-accent transition-colors">How It Works</p>
+          <p className="text-xs text-[var(--text-muted)] mt-1">3 simple steps</p>
+        </a>
+      </nav>
+
       {/* Footer */}
-      <footer className="mt-16 text-center text-xs text-[var(--text-muted)] space-y-2">
+      <footer className="mt-12 text-center text-xs text-[var(--text-muted)] space-y-2">
         <nav className="flex gap-4 justify-center">
+          <a href="/about" className="text-emerald-accent/70 hover:text-emerald-accent">About</a>
+          <a href="/faq" className="text-emerald-accent/70 hover:text-emerald-accent">FAQ</a>
           <a href="/privacy" className="text-emerald-accent/70 hover:text-emerald-accent">Privacy Policy</a>
           <a href="/terms" className="text-emerald-accent/70 hover:text-emerald-accent">Terms of Service</a>
         </nav>


### PR DESCRIPTION
Homepage now shows only:
- Hero headline + multi-step lead capture form
- Required legal disclaimers + CCPA link
- Trust signals
- Quick-link cards to About, FAQ, How It Works
- Compact footer with all page links

Moved content to dedicated pages:
- /faq — expanded FAQ (8 questions, up from 4)
- /about — already had mission, how it works, who we serve
- Added #how-it-works anchor on About page

https://claude.ai/code/session_01XtK5Mnjqtt3UJCpuijzmtG