### PR TITLE
Fix pattern loss: remove minCoherency 0.6 filter from all sync paths

### DIFF
--- a/src/api/oracle-core-lifecycle.js
+++ b/src/api/oracle-core-lifecycle.js
@@ -67,7 +67,7 @@ module.exports = {
         const { syncToGlobal } = require('../core/persistence');
         const sqliteStore = this.store.getSQLiteStore();
         if (sqliteStore) {
-          syncToGlobal(sqliteStore, { minCoherency: 0.6 });
+          syncToGlobal(sqliteStore, { minCoherency: 0.0 });
           report.synced = true;
         }
       } catch (e) {

--- a/src/api/oracle.js
+++ b/src/api/oracle.js
@@ -82,7 +82,7 @@ class RemembranceOracle {
         if (hasGlobalStore()) {
           const sqliteStore = this.store.getSQLiteStore ? this.store.getSQLiteStore() : null;
           if (sqliteStore) {
-            syncFromGlobal(sqliteStore, { minCoherency: 0.6 });
+            syncFromGlobal(sqliteStore, { minCoherency: 0.0 });
           }
         }
       } catch (e) {

--- a/src/ci/auto-submit.js
+++ b/src/ci/auto-submit.js
@@ -112,7 +112,7 @@ function autoSubmit(oracle, baseDir, options = {}) {
       const { syncToGlobal } = require('../core/persistence');
       const sqliteStore = oracle.store?.getSQLiteStore?.();
       if (sqliteStore) {
-        const syncResult = syncToGlobal(sqliteStore, { minCoherency: 0.6 });
+        const syncResult = syncToGlobal(sqliteStore, { minCoherency: 0.0 });
         report.synced = true;
         if (!silent && syncResult?.synced > 0) {
           log(`Synced ${syncResult.synced} pattern(s) to personal store`);

--- a/src/core/persistence.js
+++ b/src/core/persistence.js
@@ -113,7 +113,7 @@ function transferPattern(pattern, targetStore) {
  * This is the automatic private sync — runs on every `oracle sync`.
  */
 function syncToGlobal(localStore, options = {}) {
-  const { verbose = false, dryRun = false, minCoherency = 0.6 } = options;
+  const { verbose = false, dryRun = false, minCoherency = 0.0 } = options;
   const personalStore = openPersonalStore();
   if (!personalStore) {
     return { synced: 0, skipped: 0, total: 0, error: 'No SQLite available' };
@@ -355,7 +355,7 @@ function shareToCommunity(localStore, options = {}) {
  * Users can browse and selectively pull community patterns.
  */
 function pullFromCommunity(localStore, options = {}) {
-  const { verbose = false, dryRun = false, language, minCoherency = 0.6, maxPull = Infinity, nameFilter } = options;
+  const { verbose = false, dryRun = false, language, minCoherency = 0.0, maxPull = Infinity, nameFilter } = options;
   const communityStore = openCommunityStore();
   if (!communityStore) {
     return { pulled: 0, skipped: 0, total: 0, error: 'No SQLite available' };

--- a/src/evolution/daemon.js
+++ b/src/evolution/daemon.js
@@ -139,7 +139,7 @@ function startDaemon(oracle, options = {}) {
           const { syncToGlobal } = require('../core/persistence');
           const sqliteStore = oracle.store?.getSQLiteStore?.();
           if (sqliteStore) {
-            syncToGlobal(sqliteStore, { minCoherency: 0.6 });
+            syncToGlobal(sqliteStore, { minCoherency: 0.0 });
             report.sync = { synced: true };
           }
         } catch (err) {

--- a/src/evolution/lifecycle.js
+++ b/src/evolution/lifecycle.js
@@ -220,13 +220,13 @@ class LifecycleEngine {
     if (this.config.autoSyncOnCycle) {
       try {
         if (this._syncToGlobal) {
-          report.sync = this._syncToGlobal({ minCoherency: 0.6 });
+          report.sync = this._syncToGlobal({ minCoherency: 0.0 });
         } else {
           // Fallback for raw oracle
           const { syncToGlobal } = require('../core/persistence');
           const sqliteStore = this.oracle.store?.getSQLiteStore?.();
           if (sqliteStore) {
-            syncToGlobal(sqliteStore, { minCoherency: 0.6 });
+            syncToGlobal(sqliteStore, { minCoherency: 0.0 });
             report.sync = { synced: true };
           }
         }


### PR DESCRIPTION
Every sync path (push to personal, pull from personal, auto-submit, lifecycle, daemon) had a hardcoded minCoherency: 0.6 threshold that silently dropped patterns below that coherency during sync operations. This meant patterns seeded or registered with lower coherency scores would never make it to the personal store and would be lost if the local .remembrance/ directory was deleted.

Changed all sync-path minCoherency defaults from 0.6 to 0.0 so every pattern is preserved regardless of coherency score. Quality thresholds are still enforced at submission time and in user-facing commands (self-manage, self-optimize, team settings).

Files changed:
- src/api/oracle.js: auto-pull on empty library
- src/api/oracle-core-lifecycle.js: autoSync after pattern proven
- src/ci/auto-submit.js: auto-submit pipeline sync
- src/core/persistence.js: syncToGlobal + pullFromCommunity defaults
- src/evolution/daemon.js: daemon maintenance sync
- src/evolution/lifecycle.js: lifecycle cycle sync (2 paths)

https://claude.ai/code/session_01B83mqmsSa6CnWor7idyjNe