### PR TITLE
Replace balance-based purchases with Stripe Checkout

### DIFF
--- a/digital-cathedral/app/api/client/purchase/route.ts
+++ b/digital-cathedral/app/api/client/purchase/route.ts
@@ -2,20 +2,20 @@ import { NextRequest, NextResponse } from "next/server";
 import { verifyClient } from "@/app/lib/client-auth";
 import {
   getClientById,
-  createPurchase,
-  updateClientBalance,
   getPurchasesByLead,
   getClientDailyPurchaseCount,
   getClientMonthlyPurchaseCount,
-  generatePurchaseId,
 } from "@/app/lib/client-database";
 import { getLeadById } from "@/app/lib/database";
 import { scoreLead } from "@/app/lib/lead-scoring";
+import { stripe } from "@/app/lib/stripe";
 
 /**
  * Client Purchase API
  *
- * POST /api/client/purchase — Buy a lead
+ * POST /api/client/purchase — Create a Stripe Checkout Session for a lead purchase.
+ * Returns a checkout URL that the client is redirected to for payment.
+ * The purchase is fulfilled in /api/client/purchase/success after payment.
  */
 export async function POST(req: NextRequest) {
   const auth = await verifyClient(req);
@@ -83,65 +83,39 @@ export async function POST(req: NextRequest) {
     const isExclusive = exclusive === true;
     const price = isExclusive ? client.exclusivePrice : client.pricePerLead;
 
-    // Balance check
-    if (client.balance < price) {
-      return NextResponse.json(
-        { success: false, message: `Insufficient balance. Need $${(price / 100).toFixed(2)}, have $${(client.balance / 100).toFixed(2)}.` },
-        { status: 402 }
-      );
-    }
+    // Create Stripe Checkout Session (pay-per-lead, no stored balance)
+    const origin = req.headers.get("origin") || req.headers.get("host") || "";
+    const baseUrl = origin.startsWith("http") ? origin : `https://${origin}`;
 
-    // Deduct balance
-    const balanceResult = await updateClientBalance(auth.clientId, -price);
-    if (!balanceResult.ok) {
-      return NextResponse.json({ success: false, message: "Payment failed." }, { status: 500 });
-    }
-
-    // Create purchase
-    const returnDeadline = new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString();
-    const purchaseId = generatePurchaseId();
-
-    const purchaseResult = await createPurchase({
-      purchaseId,
-      leadId,
-      clientId: auth.clientId,
-      pricePaid: price,
-      purchasedAt: new Date().toISOString(),
-      status: "delivered",
-      exclusive: isExclusive,
-      returnReason: "",
-      returnDeadline,
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      payment_method_types: ["card", "us_bank_account", "cashapp"],
+      line_items: [
+        {
+          price_data: {
+            currency: "usd",
+            unit_amount: price,
+            product_data: {
+              name: `${isExclusive ? "Exclusive" : "Shared"} Lead — ${lead.state}`,
+              description: `Lead #${leadId.slice(0, 12)}… | ${lead.coverageInterest} | Score: ${score.total}`,
+            },
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: {
+        clientId: auth.clientId,
+        leadId,
+        exclusive: isExclusive ? "true" : "false",
+        price: String(price),
+      },
+      success_url: `${baseUrl}/portal?tab=purchases&payment=success&session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${baseUrl}/portal?tab=leads&payment=cancelled`,
     });
 
-    if (!purchaseResult.ok) {
-      // Refund on failure
-      await updateClientBalance(auth.clientId, price);
-      return NextResponse.json({ success: false, message: "Purchase failed." }, { status: 500 });
-    }
-
-    // Return full lead data now that it's purchased
     return NextResponse.json({
       success: true,
-      purchaseId,
-      lead: {
-        leadId: lead.leadId,
-        firstName: lead.firstName,
-        lastName: lead.lastName,
-        email: lead.email,
-        phone: lead.phone,
-        dateOfBirth: lead.dateOfBirth,
-        state: lead.state,
-        coverageInterest: lead.coverageInterest,
-        veteranStatus: lead.veteranStatus,
-        militaryBranch: lead.militaryBranch,
-        score: score.total,
-        tier: score.tier,
-        createdAt: lead.createdAt,
-      },
-      pricePaid: price,
-      exclusive: isExclusive,
-      returnDeadline,
-      newBalance: balanceResult.value.newBalance,
+      checkoutUrl: session.url,
     });
   } catch {
     return NextResponse.json({ success: false, message: "Invalid request." }, { status: 400 });

--- a/digital-cathedral/app/api/client/purchase/success/route.ts
+++ b/digital-cathedral/app/api/client/purchase/success/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyClient } from "@/app/lib/client-auth";
+import {
+  createPurchase,
+  generatePurchaseId,
+} from "@/app/lib/client-database";
+import { getLeadById } from "@/app/lib/database";
+import { scoreLead } from "@/app/lib/lead-scoring";
+import { stripe } from "@/app/lib/stripe";
+
+/**
+ * Purchase Success Callback
+ *
+ * GET /api/client/purchase/success?session_id=cs_xxx
+ *
+ * Called after Stripe Checkout completes. Verifies payment and fulfills the lead purchase.
+ */
+export async function GET(req: NextRequest) {
+  const auth = await verifyClient(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const sessionId = req.nextUrl.searchParams.get("session_id");
+  if (!sessionId) {
+    return NextResponse.json({ success: false, message: "Missing session_id." }, { status: 400 });
+  }
+
+  try {
+    // Retrieve the Stripe Checkout Session
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+
+    if (session.payment_status !== "paid") {
+      return NextResponse.json({ success: false, message: "Payment not completed." }, { status: 402 });
+    }
+
+    const { clientId, leadId, exclusive, price } = session.metadata || {};
+
+    // Verify the session belongs to the authenticated client
+    if (clientId !== auth.clientId) {
+      return NextResponse.json({ success: false, message: "Unauthorized." }, { status: 403 });
+    }
+
+    if (!leadId || !price) {
+      return NextResponse.json({ success: false, message: "Invalid session metadata." }, { status: 400 });
+    }
+
+    const isExclusive = exclusive === "true";
+    const pricePaid = parseInt(price, 10);
+
+    // Get lead data for the response
+    const leadResult = await getLeadById(leadId);
+    if (!leadResult.ok || !leadResult.value) {
+      return NextResponse.json({ success: false, message: "Lead not found." }, { status: 404 });
+    }
+    const lead = leadResult.value;
+    const score = scoreLead(lead);
+
+    // Create the purchase record
+    const returnDeadline = new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString();
+    const purchaseId = generatePurchaseId();
+
+    const purchaseResult = await createPurchase({
+      purchaseId,
+      leadId,
+      clientId: auth.clientId,
+      pricePaid,
+      purchasedAt: new Date().toISOString(),
+      status: "delivered",
+      exclusive: isExclusive,
+      returnReason: "",
+      returnDeadline,
+    });
+
+    if (!purchaseResult.ok) {
+      return NextResponse.json({ success: false, message: "Failed to record purchase." }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      purchaseId,
+      lead: {
+        leadId: lead.leadId,
+        firstName: lead.firstName,
+        lastName: lead.lastName,
+        email: lead.email,
+        phone: lead.phone,
+        dateOfBirth: lead.dateOfBirth,
+        state: lead.state,
+        coverageInterest: lead.coverageInterest,
+        veteranStatus: lead.veteranStatus,
+        militaryBranch: lead.militaryBranch,
+        score: score.total,
+        tier: score.tier,
+        createdAt: lead.createdAt,
+      },
+      pricePaid,
+      exclusive: isExclusive,
+      returnDeadline,
+    });
+  } catch {
+    return NextResponse.json({ success: false, message: "Failed to verify payment." }, { status: 500 });
+  }
+}

--- a/digital-cathedral/app/lib/lead-distribution.ts
+++ b/digital-cathedral/app/lib/lead-distribution.ts
@@ -5,7 +5,6 @@
  *   - Client filters (state, coverage, veteran, min score)
  *   - Cap enforcement (daily + monthly limits)
  *   - Distribution mode (exclusive, shared, round-robin)
- *   - Balance checks (prepaid model)
  *
  * Called after a lead is persisted, scored, and broadcast.
  */
@@ -16,7 +15,6 @@ import {
   getClientDailyPurchaseCount,
   getClientMonthlyPurchaseCount,
   createPurchase,
-  updateClientBalance,
   generatePurchaseId,
 } from "./client-database";
 import type { ClientRecord, LeadPurchase } from "./client-database";
@@ -123,12 +121,6 @@ async function matchClientToLead(
     return { match: false, exclusive: false, reason: `Coverage ${lead.coverageInterest} not wanted` };
   }
 
-  // Check balance
-  const price = client.pricePerLead;
-  if (client.balance < price) {
-    return { match: false, exclusive: false, reason: "Insufficient balance" };
-  }
-
   // Check daily cap
   const dailyResult = await getClientDailyPurchaseCount(client.clientId);
   if (dailyResult.ok && dailyResult.value >= client.dailyCap) {
@@ -189,10 +181,6 @@ async function executePurchase(
 ): Promise<{ clientId: string; purchaseId: string; exclusive: boolean } | null> {
   const price = exclusive ? client.exclusivePrice : client.pricePerLead;
 
-  // Deduct balance
-  const balanceResult = await updateClientBalance(client.clientId, -price);
-  if (!balanceResult.ok) return null;
-
   // Create return deadline (72 hours from now)
   const returnDeadline = new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString();
 
@@ -209,11 +197,7 @@ async function executePurchase(
   };
 
   const result = await createPurchase(purchase);
-  if (!result.ok) {
-    // Refund on failure
-    await updateClientBalance(client.clientId, price);
-    return null;
-  }
+  if (!result.ok) return null;
 
   return { clientId: client.clientId, purchaseId: purchase.purchaseId, exclusive };
 }

--- a/digital-cathedral/app/portal/page.tsx
+++ b/digital-cathedral/app/portal/page.tsx
@@ -179,6 +179,35 @@ export default function ClientPortal() {
     else if (tab === "filters") fetchFilters();
   }, [tab, fetchLeads, fetchPurchases, fetchBilling, fetchFilters]);
 
+  // Handle payment return from Stripe Checkout
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const payment = params.get("payment");
+    const sessionId = params.get("session_id");
+    const tabParam = params.get("tab") as Tab | null;
+
+    if (tabParam) setTab(tabParam);
+
+    if (payment === "success" && sessionId) {
+      // Fulfill the purchase via the success callback
+      fetch(`/api/client/purchase/success?session_id=${sessionId}`)
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.success) {
+            setMessage(`Lead purchased! ${data.exclusive ? "(Exclusive)" : "(Shared)"} — $${(data.pricePaid / 100).toFixed(2)}`);
+          } else {
+            setMessage(data.message || "Purchase fulfillment issue — contact support.");
+          }
+        })
+        .catch(() => setMessage("Could not verify payment — contact support."));
+      // Clean URL params
+      window.history.replaceState({}, "", "/portal");
+    } else if (payment === "cancelled") {
+      setMessage("Payment cancelled. You have not been charged.");
+      window.history.replaceState({}, "", "/portal");
+    }
+  }, []);
+
   const handlePurchase = async (leadId: string, exclusive: boolean) => {
     setMessage("");
     const res = await fetch("/api/client/purchase", {
@@ -187,9 +216,9 @@ export default function ClientPortal() {
       body: JSON.stringify({ leadId, exclusive }),
     });
     const data = await res.json();
-    if (data.success) {
-      setMessage(`Lead purchased! ${exclusive ? "(Exclusive)" : "(Shared)"} — $${(data.pricePaid / 100).toFixed(2)}`);
-      fetchLeads();
+    if (data.success && data.checkoutUrl) {
+      // Redirect to Stripe Checkout
+      window.location.href = data.checkoutUrl;
     } else {
       setMessage(data.message || "Purchase failed.");
     }
@@ -430,6 +459,56 @@ export default function ClientPortal() {
             </div>
           </div>
 
+          {/* How Payment Works */}
+          <div className="cathedral-surface p-6">
+            <h3 className="text-lg font-light text-[var(--text-primary)] mb-1">How Payment Works</h3>
+            <p className="text-sm text-[var(--text-muted)] mb-5">
+              Pay per lead at checkout — no stored balance needed. When you click &ldquo;Buy&rdquo; on a lead, you&apos;ll be taken to a secure Stripe checkout page.
+            </p>
+
+            <div className="mb-4">
+              <p className="text-xs metallic-gold uppercase tracking-wider mb-3">Accepted Payment Methods</p>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <div className="flex items-center gap-3 p-3 rounded-lg border border-indigo-cathedral/10 bg-[var(--bg-surface)]">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-teal-cathedral shrink-0" aria-hidden="true">
+                    <path d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z" />
+                  </svg>
+                  <div>
+                    <p className="text-sm text-[var(--text-primary)] font-medium">Credit / Debit Card</p>
+                    <p className="text-xs text-[var(--text-muted)]">Visa, Mastercard, Amex</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3 p-3 rounded-lg border border-indigo-cathedral/10 bg-[var(--bg-surface)]">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-teal-cathedral shrink-0" aria-hidden="true">
+                    <path d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0012 9.75c-2.551 0-5.056.2-7.5.582V21" />
+                  </svg>
+                  <div>
+                    <p className="text-sm text-[var(--text-primary)] font-medium">Bank Account</p>
+                    <p className="text-xs text-[var(--text-muted)]">ACH direct debit</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3 p-3 rounded-lg border border-indigo-cathedral/10 bg-[var(--bg-surface)]">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-teal-cathedral shrink-0" aria-hidden="true">
+                    <path d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <div>
+                    <p className="text-sm text-[var(--text-primary)] font-medium">Cash App</p>
+                    <p className="text-xs text-[var(--text-muted)]">Cash App Pay</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-[var(--bg-surface)] border border-indigo-cathedral/10">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="shrink-0 mt-0.5 text-teal-cathedral" aria-hidden="true">
+                <path d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+              </svg>
+              <p className="text-xs text-[var(--text-muted)]">
+                All payments are securely processed by Stripe. We never see or store your payment details.
+              </p>
+            </div>
+          </div>
+
           {/* Transaction History */}
           <div className="cathedral-surface overflow-x-auto">
             <div className="px-4 py-3 border-b border-indigo-cathedral/10">
@@ -446,7 +525,7 @@ export default function ClientPortal() {
               </thead>
               <tbody>
                 {billing.length === 0 ? (
-                  <tr><td colSpan={4} className="px-4 py-8 text-center text-[var(--text-muted)]">No transactions yet. Add funds to get started.</td></tr>
+                  <tr><td colSpan={4} className="px-4 py-8 text-center text-[var(--text-muted)]">No transactions yet. Purchase a lead to get started.</td></tr>
                 ) : (
                   billing.map((b) => (
                     <tr key={b.billingId} className="border-b border-indigo-cathedral/5">


### PR DESCRIPTION
Clients no longer need a stored balance. When clicking "Buy" on a lead, they're redirected to a Stripe Checkout page that accepts credit/debit card, bank account (ACH), and Cash App. The purchase is fulfilled via a success callback after Stripe confirms payment.

Changes:
- Purchase API now creates a Stripe Checkout Session and returns the URL
- New /api/client/purchase/success endpoint fulfills after payment
- Removed balance checks from purchase API and lead-distribution engine
- Portal redirects to Stripe Checkout on "Buy" click
- Billing tab shows accepted payment methods (card, bank, Cash App)
- Handles ?payment=success and ?payment=cancelled return URLs

https://claude.ai/code/session_01B83mqmsSa6CnWor7idyjNe