### PR TITLE
Fix build failures: lazy Stripe init + TypeScript cast

### DIFF
--- a/digital-cathedral/app/lib/lead-depreciation.ts
+++ b/digital-cathedral/app/lib/lead-depreciation.ts
@@ -66,7 +66,7 @@ export const PURCHASE_TIERS = new Proxy([] as PurchaseTier[], {
     if (typeof prop === "string" && !isNaN(Number(prop))) {
       return tiers[Number(prop)];
     }
-    return (tiers as Record<string | symbol, unknown>)[prop];
+    return (tiers as unknown as Record<string | symbol, unknown>)[prop];
   },
 });
 

--- a/digital-cathedral/app/lib/stripe.ts
+++ b/digital-cathedral/app/lib/stripe.ts
@@ -1,17 +1,31 @@
 /**
  * Stripe Server-Side Configuration
  *
- * Initializes the Stripe SDK for server-side usage (API routes, webhooks).
+ * Initializes the Stripe SDK lazily for server-side usage (API routes, webhooks).
  * Uses STRIPE_SECRET_KEY from environment variables.
+ * Lazy init prevents build failures when the env var isn't available at build time.
  */
 
 import Stripe from "stripe";
 
-if (!process.env.STRIPE_SECRET_KEY) {
-  throw new Error("STRIPE_SECRET_KEY is not set in environment variables");
+let _stripe: Stripe | null = null;
+
+export function getStripe(): Stripe {
+  if (!_stripe) {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      throw new Error("STRIPE_SECRET_KEY is not set in environment variables");
+    }
+    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: "2026-02-25.clover",
+      typescript: true,
+    });
+  }
+  return _stripe;
 }
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2026-02-25.clover",
-  typescript: true,
+/** @deprecated Use getStripe() instead — kept for backwards compat during migration */
+export const stripe = new Proxy({} as Stripe, {
+  get(_target, prop) {
+    return (getStripe() as unknown as Record<string | symbol, unknown>)[prop];
+  },
 });


### PR DESCRIPTION
- stripe.ts: Use lazy initialization via Proxy so STRIPE_SECRET_KEY is only required at request time, not build time. Fixes Vercel deploy failure during static page collection.
- lead-depreciation.ts: Fix TS2352 by casting through unknown first.

https://claude.ai/code/session_01B83mqmsSa6CnWor7idyjNe