### PR TITLE
Bypass client portal login in demo mode (no DATABASE_URL)

### DIFF
--- a/digital-cathedral/app/api/client/login/route.ts
+++ b/digital-cathedral/app/api/client/login/route.ts
@@ -6,9 +6,24 @@ import { createClientSessionToken, CLIENT_SESSION_COOKIE, CLIENT_SESSION_MAX_AGE
  * Client Login API
  *
  * POST /api/client/login — Authenticate client and set session cookie
+ *
+ * In demo mode (no DATABASE_URL), any credentials succeed — the demo
+ * client is automatically authenticated.
  */
 export async function POST(req: NextRequest) {
   try {
+    // Demo mode — skip credential check, auto-authenticate
+    if (!process.env.DATABASE_URL) {
+      const { DEMO_CLIENT } = await import("@/app/lib/demo-client");
+      const response = NextResponse.json({
+        success: true,
+        clientId: DEMO_CLIENT.clientId,
+        companyName: DEMO_CLIENT.companyName,
+      });
+      // No cookie needed in demo mode — verifyClient bypasses auth
+      return response;
+    }
+
     const body = await req.json();
     const { email, password } = body;
 

--- a/digital-cathedral/app/lib/client-auth.ts
+++ b/digital-cathedral/app/lib/client-auth.ts
@@ -4,6 +4,9 @@
  * Separate from admin auth. Uses HMAC-SHA256 signed cookies.
  * Cookie format: <payload>.<signature>
  * Payload: base64url(JSON.stringify({ clientId, email, exp }))
+ *
+ * In demo mode (no DATABASE_URL), authentication is bypassed entirely —
+ * all requests are auto-authenticated as the demo client.
  */
 
 import { createHmac } from "crypto";
@@ -11,7 +14,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { getClientById } from "./client-database";
 
 const COOKIE_NAME = "__client_session";
-const SESSION_DURATION_S = 8 * 60 * 60; // 8 hours
+const SESSION_DURATION_S = 30 * 24 * 60 * 60; // 30 days
+
+/** True when no real database is configured — auto-auth as demo client. */
+function isDemoMode(): boolean {
+  return !process.env.DATABASE_URL;
+}
 
 function getSecret(): string {
   const key = process.env.CLIENT_SESSION_SECRET || process.env.ADMIN_API_KEY;
@@ -58,8 +66,17 @@ export function verifyClientSessionToken(token: string): { clientId: string; ema
 /**
  * Verify client authentication from request.
  * Returns the client ID if authenticated, or a 401 response.
+ *
+ * In demo mode (no DATABASE_URL), always returns the demo client —
+ * no login required.
  */
 export async function verifyClient(req: NextRequest): Promise<{ clientId: string } | NextResponse> {
+  // Demo mode — bypass auth entirely
+  if (isDemoMode()) {
+    const { DEMO_CLIENT } = await import("./demo-client");
+    return { clientId: DEMO_CLIENT.clientId };
+  }
+
   // Method 1: Session cookie
   const sessionCookie = req.cookies.get(COOKIE_NAME)?.value;
   if (sessionCookie) {

--- a/digital-cathedral/app/portal/login/page.tsx
+++ b/digital-cathedral/app/portal/login/page.tsx
@@ -4,7 +4,7 @@
  * Client Portal Login Page
  */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 
 export default function ClientLoginPage() {
@@ -13,6 +13,13 @@ export default function ClientLoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  // In demo mode, auto-login immediately on mount
+  useEffect(() => {
+    fetch("/api/client/profile").then((res) => {
+      if (res.ok) router.push("/portal");
+    }).catch(() => {});
+  }, [router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
When no DATABASE_URL is configured, the client portal now auto- authenticates as the demo client — no credentials needed. verifyClient() returns demo client identity immediately, login API auto-succeeds, and the login page auto-redirects to /portal on mount.

Session duration extended from 8 hours to 30 days for real DB mode.

https://claude.ai/code/session_01B83mqmsSa6CnWor7idyjNe