### PR TITLE
Restore admin login button on client portal welcome page

### DIFF
--- a/digital-cathedral/app/portal/page.tsx
+++ b/digital-cathedral/app/portal/page.tsx
@@ -154,6 +154,19 @@ export default function PortalWelcomePage() {
           </div>
         </div>
 
+        {/* Admin Login */}
+        <div className="text-center">
+          <Link
+            href="/admin/login"
+            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all border border-indigo-cathedral/20 text-[var(--text-muted)] hover:border-teal-cathedral/40 hover:text-teal-cathedral"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.746 3.746 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z" />
+            </svg>
+            Admin Login
+          </Link>
+        </div>
+
         {/* Quick Links */}
         <div className="text-center space-y-2">
           <p className="text-xs text-[var(--text-muted)]">


### PR DESCRIPTION
Adds an "Admin Login" button linking to /admin/login on the portal welcome page, positioned between the feature icons and the quick links. The button was lost when the page was rewritten from a full dashboard to a dedicated welcome/login page.

https://claude.ai/code/session_016AqXS1CPTHEBoUCXLrR5Ua