### PR TITLE
Fix client portal login and add admin owner client account

### DIFF
--- a/digital-cathedral/app/api/admin/seed-client/route.ts
+++ b/digital-cathedral/app/api/admin/seed-client/route.ts
@@ -10,28 +10,69 @@ import {
 import type { ClientRecord } from "@/app/lib/client-database";
 
 /**
- * Seed Test Client API
+ * Seed Client Accounts API
  *
- * POST /api/admin/seed-client — Creates a test client for portal access.
+ * POST /api/admin/seed-client — Creates the admin owner client and a test client.
  * Protected by admin auth. Idempotent — won't duplicate if already exists.
  */
 
+// Admin owner account — full access to inspect the client portal
+const ADMIN_CLIENT_EMAIL = "admin@valorlegacies.xyz";
+const ADMIN_CLIENT_PASSWORD = "ValorOwner2026!";
+
+// Test buyer account
 const TEST_EMAIL = "testclient@valorlegacies.com";
 const TEST_PASSWORD = "ClientPortal2026!";
 
-export async function POST(req: NextRequest) {
-  const authError = await verifyAdmin(req);
-  if (authError) return authError;
+interface SeedSpec {
+  email: string;
+  password: string;
+  companyName: string;
+  contactName: string;
+  phone: string;
+  pricingTier: string;
+  pricePerLead: number;
+  exclusivePrice: number;
+  stateLicenses: string[];
+  dailyCap: number;
+  monthlyCap: number;
+}
 
-  // Check if test client already exists
-  const existing = await getClientByEmail(TEST_EMAIL);
+const SEED_ACCOUNTS: SeedSpec[] = [
+  {
+    email: ADMIN_CLIENT_EMAIL,
+    password: ADMIN_CLIENT_PASSWORD,
+    companyName: "Valor Legacies (Owner)",
+    contactName: "Admin Owner",
+    phone: "5550000001",
+    pricingTier: "enterprise",
+    pricePerLead: 0,
+    exclusivePrice: 0,
+    stateLicenses: ["TX", "FL", "CA", "NY", "PA", "GA", "NC", "VA", "OH", "IL", "AZ", "CO", "WA", "OR", "NV"],
+    dailyCap: 9999,
+    monthlyCap: 99999,
+  },
+  {
+    email: TEST_EMAIL,
+    password: TEST_PASSWORD,
+    companyName: "Valor Test Agency",
+    contactName: "Test Buyer",
+    phone: "5551234567",
+    pricingTier: "standard",
+    pricePerLead: 2500,
+    exclusivePrice: 5000,
+    stateLicenses: ["TX", "FL", "CA", "NY", "PA", "GA", "NC", "VA", "OH", "IL"],
+    dailyCap: 50,
+    monthlyCap: 1000,
+  },
+];
+
+const ALL_COVERAGE_TYPES = ["mortgage-protection", "income-replacement", "final-expense", "legacy", "retirement-savings", "guaranteed-income"];
+
+async function seedAccount(spec: SeedSpec): Promise<{ created: boolean; clientId: string; email: string; password: string; error?: string }> {
+  const existing = await getClientByEmail(spec.email);
   if (existing.ok && existing.value) {
-    return NextResponse.json({
-      success: true,
-      message: "Test client already exists.",
-      credentials: { email: TEST_EMAIL, password: TEST_PASSWORD },
-      clientId: existing.value.clientId,
-    });
+    return { created: false, clientId: existing.value.clientId, email: spec.email, password: spec.password };
   }
 
   const now = new Date().toISOString();
@@ -39,19 +80,19 @@ export async function POST(req: NextRequest) {
 
   const client: ClientRecord = {
     clientId,
-    companyName: "Valor Test Agency",
-    contactName: "Test Buyer",
-    email: TEST_EMAIL,
-    phone: "5551234567",
-    passwordHash: hashPassword(TEST_PASSWORD),
+    companyName: spec.companyName,
+    contactName: spec.contactName,
+    email: spec.email,
+    phone: spec.phone,
+    passwordHash: hashPassword(spec.password),
     status: "active",
-    pricingTier: "standard",
-    pricePerLead: 2500,       // $25.00
-    exclusivePrice: 5000,     // $50.00
-    stateLicenses: JSON.stringify(["TX", "FL", "CA", "NY", "PA", "GA", "NC", "VA", "OH", "IL"]),
-    coverageTypes: JSON.stringify(["mortgage-protection", "income-replacement", "final-expense", "legacy", "retirement-savings", "guaranteed-income"]),
-    dailyCap: 50,
-    monthlyCap: 1000,
+    pricingTier: spec.pricingTier,
+    pricePerLead: spec.pricePerLead,
+    exclusivePrice: spec.exclusivePrice,
+    stateLicenses: JSON.stringify(spec.stateLicenses),
+    coverageTypes: JSON.stringify(ALL_COVERAGE_TYPES),
+    dailyCap: spec.dailyCap,
+    monthlyCap: spec.monthlyCap,
     minScore: 0,
     balance: 0,
     createdAt: now,
@@ -60,10 +101,9 @@ export async function POST(req: NextRequest) {
 
   const result = await createClient(client);
   if (!result.ok) {
-    return NextResponse.json({ success: false, message: result.error }, { status: 500 });
+    return { created: false, clientId: "", email: spec.email, password: spec.password, error: String(result.error) };
   }
 
-  // Set default filters
   await upsertClientFilters({
     clientId,
     states: JSON.stringify([]),
@@ -74,17 +114,25 @@ export async function POST(req: NextRequest) {
     distributionMode: "shared",
   });
 
+  return { created: true, clientId, email: spec.email, password: spec.password };
+}
+
+export async function POST(req: NextRequest) {
+  const authError = await verifyAdmin(req);
+  if (authError) return authError;
+
+  const results = await Promise.all(SEED_ACCOUNTS.map(seedAccount));
+
+  const accounts = results.map((r) => ({
+    email: r.email,
+    password: r.password,
+    clientId: r.clientId,
+    status: r.error ? `error: ${r.error}` : r.created ? "created" : "already exists",
+  }));
+
   return NextResponse.json({
-    success: true,
-    message: "Test client created successfully.",
-    credentials: { email: TEST_EMAIL, password: TEST_PASSWORD },
-    clientId,
-    details: {
-      companyName: client.companyName,
-      balance: "$0.00",
-      pricePerLead: "$25.00",
-      exclusivePrice: "$50.00",
-      licensedStates: 10,
-    },
+    success: results.every((r) => !r.error),
+    message: "Client accounts seeded.",
+    accounts,
   });
 }

--- a/digital-cathedral/app/api/client/login/route.ts
+++ b/digital-cathedral/app/api/client/login/route.ts
@@ -8,7 +8,7 @@ import { checkRateLimit, getClientIp } from "@/app/lib/rate-limit";
  *
  * POST /api/client/login — Authenticate client and set session cookie.
  * In demo mode (no DATABASE_URL), any credentials succeed — the demo
- * client is auto-authenticated without cookie or signing secret.
+ * client is auto-authenticated with a proper session cookie.
  */
 export async function POST(req: NextRequest) {
   try {
@@ -22,16 +22,6 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Demo mode — auto-succeed (development only, never in production)
-    if (!process.env.DATABASE_URL && process.env.NODE_ENV !== "production") {
-      const { DEMO_CLIENT } = await import("@/app/lib/demo-client");
-      return NextResponse.json({
-        success: true,
-        clientId: DEMO_CLIENT.clientId,
-        companyName: DEMO_CLIENT.companyName,
-      });
-    }
-
     const body = await req.json();
     const { email, password } = body;
 
@@ -40,6 +30,43 @@ export async function POST(req: NextRequest) {
         { success: false, message: "Email and password are required." },
         { status: 400 }
       );
+    }
+
+    // Demo mode — verify against demo client credentials (development only)
+    if (!process.env.DATABASE_URL && process.env.NODE_ENV !== "production") {
+      const { DEMO_CLIENT } = await import("@/app/lib/demo-client");
+      const { verifyPassword: verifyPw } = await import("@/app/lib/client-database");
+      const emailMatch = email.trim().toLowerCase() === DEMO_CLIENT.email.toLowerCase();
+      const pwMatch = verifyPw(password, DEMO_CLIENT.passwordHash);
+      if (!emailMatch || !pwMatch) {
+        return NextResponse.json(
+          { success: false, message: "Invalid credentials." },
+          { status: 401 }
+        );
+      }
+
+      const response = NextResponse.json({
+        success: true,
+        clientId: DEMO_CLIENT.clientId,
+        companyName: DEMO_CLIENT.companyName,
+      });
+
+      // Set session cookie even in demo mode so the portal dashboard works
+      try {
+        const token = createClientSessionToken(DEMO_CLIENT.clientId, DEMO_CLIENT.email);
+        response.cookies.set(CLIENT_SESSION_COOKIE, token, {
+          httpOnly: true,
+          secure: false,
+          sameSite: "lax",
+          maxAge: CLIENT_SESSION_MAX_AGE,
+          path: "/",
+        });
+      } catch {
+        // If no signing secret is configured in dev, still let the login succeed
+        // (verifyClient bypasses cookie check in demo mode)
+      }
+
+      return response;
     }
 
     const clientResult = await getClientByEmail(email.trim().toLowerCase());

--- a/digital-cathedral/app/lib/demo-client.ts
+++ b/digital-cathedral/app/lib/demo-client.ts
@@ -1,8 +1,12 @@
 /**
  * Demo Client Data
  *
- * Hardcoded test client for the client portal when no DATABASE_URL is configured.
- * Password is pre-hashed so verifyPassword("ClientPortal2026!", hash) returns true.
+ * Hardcoded admin owner client for the client portal when no DATABASE_URL is configured.
+ * Password is pre-hashed so verifyPassword("ValorOwner2026!", hash) returns true.
+ *
+ * Credentials (local dev):
+ *   Email:    admin@valorlegacies.xyz
+ *   Password: ValorOwner2026!
  */
 
 import { createHmac } from "crypto";
@@ -10,25 +14,25 @@ import type { ClientRecord, ClientFilters, LeadPurchase, ClientBilling, ClientSt
 
 // Pre-compute a deterministic hash so we don't need randomBytes at import time
 const DEMO_SALT = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
-const DEMO_HASH = createHmac("sha256", DEMO_SALT).update("ClientPortal2026!").digest("hex");
+const DEMO_HASH = createHmac("sha256", DEMO_SALT).update("ValorOwner2026!").digest("hex");
 
 const now = new Date().toISOString();
 
 export const DEMO_CLIENT: ClientRecord = {
-  clientId: "client_demo_001",
-  companyName: "Valor Test Agency",
-  contactName: "Test Buyer",
-  email: "testclient@valorlegacies.com",
-  phone: "5551234567",
+  clientId: "client_demo_admin",
+  companyName: "Valor Legacies (Owner)",
+  contactName: "Admin Owner",
+  email: "admin@valorlegacies.xyz",
+  phone: "5550000001",
   passwordHash: `${DEMO_SALT}:${DEMO_HASH}`,
   status: "active",
-  pricingTier: "standard",
-  pricePerLead: 2500,       // $25.00
-  exclusivePrice: 5000,     // $50.00
-  stateLicenses: JSON.stringify(["TX", "FL", "CA", "NY", "PA", "GA", "NC", "VA", "OH", "IL"]),
+  pricingTier: "enterprise",
+  pricePerLead: 0,
+  exclusivePrice: 0,
+  stateLicenses: JSON.stringify(["TX", "FL", "CA", "NY", "PA", "GA", "NC", "VA", "OH", "IL", "AZ", "CO", "WA", "OR", "NV"]),
   coverageTypes: JSON.stringify(["mortgage-protection", "income-replacement", "final-expense", "legacy", "retirement-savings", "guaranteed-income"]),
-  dailyCap: 50,
-  monthlyCap: 1000,
+  dailyCap: 9999,
+  monthlyCap: 99999,
   minScore: 0,
   balance: 0,
   createdAt: now,


### PR DESCRIPTION
Three issues fixed:

1. Demo mode login (no DATABASE_URL) returned success but never set the __client_session cookie, so the dashboard couldn't verify the session. Now sets the cookie properly and validates credentials against the demo client instead of accepting any input.

2. Created admin owner client account for the portal:
   Email:    admin@valorlegacies.xyz
   Password: ValorOwner2026!
   This account has enterprise tier, zero pricing (owner), and expanded
   state licenses so the admin can inspect everything in the client portal.

3. Seed endpoint now creates both the admin owner and test client in one call, with idempotent upsert logic for each.

https://claude.ai/code/session_016AqXS1CPTHEBoUCXLrR5Ua