### PR TITLE
Add admin master-key login for client portal, fix DB error masking

### DIFF
--- a/digital-cathedral/app/api/client/login/route.ts
+++ b/digital-cathedral/app/api/client/login/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getClientByEmail, verifyPassword } from "@/app/lib/client-database";
+import { getClientByEmail, verifyPassword, hashPassword } from "@/app/lib/client-database";
 import { createClientSessionToken, CLIENT_SESSION_COOKIE, CLIENT_SESSION_MAX_AGE } from "@/app/lib/client-auth";
 import { checkRateLimit, getClientIp } from "@/app/lib/rate-limit";
 
@@ -7,9 +7,34 @@ import { checkRateLimit, getClientIp } from "@/app/lib/rate-limit";
  * Client Login API
  *
  * POST /api/client/login — Authenticate client and set session cookie.
- * In demo mode (no DATABASE_URL), any credentials succeed — the demo
- * client is auto-authenticated with a proper session cookie.
+ *
+ * Auth paths (tried in order):
+ *  1. Admin master login — email matches CLIENT_ADMIN_EMAIL (or admin@valorlegacies.xyz)
+ *     and password matches ADMIN_API_KEY → instant session, no DB lookup needed.
+ *  2. Database lookup — email + password verified against clients table.
+ *  3. Demo mode (no DATABASE_URL, dev only) — demo client credentials.
  */
+
+/** Admin client identity used for the master-key login path. */
+const ADMIN_CLIENT_ID = "client_admin_owner";
+const ADMIN_CLIENT_EMAIL = (process.env.CLIENT_ADMIN_EMAIL ?? "admin@valorlegacies.xyz").trim().toLowerCase();
+const ADMIN_CLIENT_COMPANY = "Valor Legacies (Owner)";
+
+function setSessionCookie(
+  response: NextResponse,
+  clientId: string,
+  email: string,
+): void {
+  const token = createClientSessionToken(clientId, email);
+  response.cookies.set(CLIENT_SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: CLIENT_SESSION_MAX_AGE,
+    path: "/",
+  });
+}
+
 export async function POST(req: NextRequest) {
   try {
     // Rate limit: 5 attempts per minute per IP
@@ -28,20 +53,77 @@ export async function POST(req: NextRequest) {
     if (!email || !password) {
       return NextResponse.json(
         { success: false, message: "Email and password are required." },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    // Demo mode — verify against demo client credentials (development only)
+    const normalizedEmail = email.trim().toLowerCase();
+
+    // ─── Path 1: Admin master-key login ───
+    // The admin can always log into the client portal using their ADMIN_API_KEY
+    // as the password. This bypasses the database entirely — guaranteed to work
+    // even if the DB is unreachable, tables are missing, or seed never ran.
+    const adminApiKey = process.env.ADMIN_API_KEY;
+    if (adminApiKey && normalizedEmail === ADMIN_CLIENT_EMAIL && password === adminApiKey) {
+      // Ensure the admin client exists in the database for dashboard queries
+      try {
+        const existing = await getClientByEmail(ADMIN_CLIENT_EMAIL);
+        if (!existing.ok || !existing.value) {
+          // Auto-create the admin client row so dashboard/profile pages work
+          const { createClient, generateClientId, upsertClientFilters } = await import("@/app/lib/client-database");
+          const clientId = generateClientId();
+          await createClient({
+            clientId,
+            companyName: ADMIN_CLIENT_COMPANY,
+            contactName: "Admin Owner",
+            email: ADMIN_CLIENT_EMAIL,
+            phone: "",
+            passwordHash: hashPassword(adminApiKey),
+            status: "active",
+            pricingTier: "enterprise",
+            pricePerLead: 0,
+            exclusivePrice: 0,
+            stateLicenses: JSON.stringify(["TX", "FL", "CA", "NY", "PA", "GA", "NC", "VA", "OH", "IL", "AZ", "CO", "WA", "OR", "NV"]),
+            coverageTypes: JSON.stringify(["mortgage-protection", "income-replacement", "final-expense", "legacy", "retirement-savings", "guaranteed-income"]),
+            dailyCap: 9999,
+            monthlyCap: 99999,
+            minScore: 0,
+            balance: 0,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+          await upsertClientFilters({
+            clientId,
+            states: JSON.stringify([]),
+            coverageTypes: JSON.stringify([]),
+            veteranOnly: false,
+            minScore: 0,
+            maxLeadAge: 72,
+            distributionMode: "shared",
+          });
+        }
+      } catch {
+        // DB auto-create failed — still allow login; dashboard may show limited data
+      }
+
+      const response = NextResponse.json({
+        success: true,
+        clientId: ADMIN_CLIENT_ID,
+        companyName: ADMIN_CLIENT_COMPANY,
+      });
+      setSessionCookie(response, ADMIN_CLIENT_ID, ADMIN_CLIENT_EMAIL);
+      return response;
+    }
+
+    // ─── Path 2: Demo mode (development only) ───
     if (!process.env.DATABASE_URL && process.env.NODE_ENV !== "production") {
       const { DEMO_CLIENT } = await import("@/app/lib/demo-client");
-      const { verifyPassword: verifyPw } = await import("@/app/lib/client-database");
-      const emailMatch = email.trim().toLowerCase() === DEMO_CLIENT.email.toLowerCase();
-      const pwMatch = verifyPw(password, DEMO_CLIENT.passwordHash);
+      const emailMatch = normalizedEmail === DEMO_CLIENT.email.toLowerCase();
+      const pwMatch = verifyPassword(password, DEMO_CLIENT.passwordHash);
       if (!emailMatch || !pwMatch) {
         return NextResponse.json(
           { success: false, message: "Invalid credentials." },
-          { status: 401 }
+          { status: 401 },
         );
       }
 
@@ -51,29 +133,31 @@ export async function POST(req: NextRequest) {
         companyName: DEMO_CLIENT.companyName,
       });
 
-      // Set session cookie even in demo mode so the portal dashboard works
       try {
-        const token = createClientSessionToken(DEMO_CLIENT.clientId, DEMO_CLIENT.email);
-        response.cookies.set(CLIENT_SESSION_COOKIE, token, {
-          httpOnly: true,
-          secure: false,
-          sameSite: "lax",
-          maxAge: CLIENT_SESSION_MAX_AGE,
-          path: "/",
-        });
+        setSessionCookie(response, DEMO_CLIENT.clientId, DEMO_CLIENT.email);
       } catch {
-        // If no signing secret is configured in dev, still let the login succeed
-        // (verifyClient bypasses cookie check in demo mode)
+        // No signing secret in dev — verifyClient bypasses cookie check in demo mode
       }
 
       return response;
     }
 
-    const clientResult = await getClientByEmail(email.trim().toLowerCase());
-    if (!clientResult.ok || !clientResult.value) {
+    // ─── Path 3: Database credential lookup ───
+    const clientResult = await getClientByEmail(normalizedEmail);
+
+    // Distinguish database errors from "not found"
+    if (!clientResult.ok) {
+      console.error("[client-login] Database error looking up client:", clientResult.error);
+      return NextResponse.json(
+        { success: false, message: "Login service temporarily unavailable. Please try again." },
+        { status: 503 },
+      );
+    }
+
+    if (!clientResult.value) {
       return NextResponse.json(
         { success: false, message: "Invalid credentials." },
-        { status: 401 }
+        { status: 401 },
       );
     }
 
@@ -82,18 +166,16 @@ export async function POST(req: NextRequest) {
     if (client.status !== "active") {
       return NextResponse.json(
         { success: false, message: "Account is suspended or closed. Contact support." },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
     if (!verifyPassword(password, client.passwordHash)) {
       return NextResponse.json(
         { success: false, message: "Invalid credentials." },
-        { status: 401 }
+        { status: 401 },
       );
     }
-
-    const token = createClientSessionToken(client.clientId, client.email);
 
     const response = NextResponse.json({
       success: true,
@@ -101,16 +183,10 @@ export async function POST(req: NextRequest) {
       companyName: client.companyName,
     });
 
-    response.cookies.set(CLIENT_SESSION_COOKIE, token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: CLIENT_SESSION_MAX_AGE,
-      path: "/",
-    });
-
+    setSessionCookie(response, client.clientId, client.email);
     return response;
-  } catch {
+  } catch (err) {
+    console.error("[client-login] Unexpected error:", err);
     return NextResponse.json({ success: false, message: "Invalid request." }, { status: 400 });
   }
 }

--- a/digital-cathedral/app/api/client/profile/route.ts
+++ b/digital-cathedral/app/api/client/profile/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyClient } from "@/app/lib/client-auth";
-import { getClientById } from "@/app/lib/client-database";
+import { getClientById, getClientByEmail } from "@/app/lib/client-database";
+
+/** Admin owner identity — used when the admin master-key login has no DB row. */
+const ADMIN_CLIENT_ID = "client_admin_owner";
+const ADMIN_CLIENT_EMAIL = (process.env.CLIENT_ADMIN_EMAIL ?? "admin@valorlegacies.xyz").trim().toLowerCase();
 
 /**
  * Client Profile API
@@ -11,12 +15,46 @@ export async function GET(req: NextRequest) {
   const auth = await verifyClient(req);
   if (auth instanceof NextResponse) return auth;
 
+  // Try loading from DB by clientId first
   const result = await getClientById(auth.clientId);
-  if (!result.ok || !result.value) {
-    return NextResponse.json({ success: false, message: "Client not found." }, { status: 404 });
+  if (result.ok && result.value) {
+    const { passwordHash, ...client } = result.value;
+    return NextResponse.json({ success: true, client });
   }
 
-  const { passwordHash, ...client } = result.value;
+  // Admin owner fallback — if the admin master-key login was used but no DB row
+  // exists, try by email or return a synthetic profile so the dashboard loads.
+  if (auth.clientId === ADMIN_CLIENT_ID) {
+    const byEmail = await getClientByEmail(ADMIN_CLIENT_EMAIL);
+    if (byEmail.ok && byEmail.value) {
+      const { passwordHash, ...client } = byEmail.value;
+      return NextResponse.json({ success: true, client });
+    }
 
-  return NextResponse.json({ success: true, client });
+    // Fully synthetic — no database at all
+    return NextResponse.json({
+      success: true,
+      client: {
+        clientId: ADMIN_CLIENT_ID,
+        companyName: "Valor Legacies (Owner)",
+        contactName: "Admin Owner",
+        email: ADMIN_CLIENT_EMAIL,
+        phone: "",
+        status: "active",
+        pricingTier: "enterprise",
+        pricePerLead: 0,
+        exclusivePrice: 0,
+        stateLicenses: "[]",
+        coverageTypes: "[]",
+        dailyCap: 9999,
+        monthlyCap: 99999,
+        minScore: 0,
+        balance: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    });
+  }
+
+  return NextResponse.json({ success: false, message: "Client not found." }, { status: 404 });
 }

--- a/digital-cathedral/app/lib/client-auth.ts
+++ b/digital-cathedral/app/lib/client-auth.ts
@@ -5,9 +5,11 @@
  * Cookie format: <payload>.<signature>
  * Payload: base64url(JSON.stringify({ clientId, email, exp }))
  *
- * Oracle debug fix: in demo mode (no DATABASE_URL), auth is bypassed
- * entirely — NoopAdapter returns demo data, verifyClient returns the
- * demo client without requiring a signing secret or cookie.
+ * Special cases:
+ *  - Admin owner (client_admin_owner) — always trusted if token is valid,
+ *    no DB lookup required. Lets the admin inspect the portal even if the
+ *    clients table is empty or unreachable.
+ *  - Demo mode (no DATABASE_URL) — auth bypassed entirely.
  */
 
 import { createHmac } from "crypto";
@@ -16,6 +18,9 @@ import { getClientById } from "./client-database";
 
 const COOKIE_NAME = "__client_session";
 const SESSION_DURATION_S = 30 * 24 * 60 * 60; // 30 days
+
+/** The synthetic client ID used by admin master-key login. */
+const ADMIN_CLIENT_ID = "client_admin_owner";
 
 /** True when no real database is configured AND not in production — graceful degradation to demo client. */
 function isDemoMode(): boolean {
@@ -68,6 +73,22 @@ export function verifyClientSessionToken(token: string): { clientId: string; ema
 }
 
 /**
+ * Verify a parsed session against the database (or trust admin client directly).
+ * Returns the clientId if valid, or null if the session should be rejected.
+ */
+async function verifySession(session: { clientId: string; email: string }): Promise<string | null> {
+  // Admin owner — always trusted (no DB row required)
+  if (session.clientId === ADMIN_CLIENT_ID) return session.clientId;
+
+  // Regular client — verify row exists and is active
+  const clientResult = await getClientById(session.clientId);
+  if (clientResult.ok && clientResult.value && clientResult.value.status === "active") {
+    return session.clientId;
+  }
+  return null;
+}
+
+/**
  * Verify client authentication from request.
  * Returns the client ID if authenticated, or a 401 response.
  *
@@ -75,7 +96,7 @@ export function verifyClientSessionToken(token: string): { clientId: string; ema
  * no cookie, no signing secret, no credentials required.
  */
 export async function verifyClient(req: NextRequest): Promise<{ clientId: string } | NextResponse> {
-  // Oracle fix: demo mode — bypass auth, return demo client directly
+  // Demo mode — bypass auth, return demo client directly
   if (isDemoMode()) {
     const { DEMO_CLIENT } = await import("./demo-client");
     return { clientId: DEMO_CLIENT.clientId };
@@ -86,11 +107,8 @@ export async function verifyClient(req: NextRequest): Promise<{ clientId: string
   if (sessionCookie) {
     const session = verifyClientSessionToken(sessionCookie);
     if (session) {
-      // Verify client still exists and is active
-      const clientResult = await getClientById(session.clientId);
-      if (clientResult.ok && clientResult.value && clientResult.value.status === "active") {
-        return { clientId: session.clientId };
-      }
+      const clientId = await verifySession(session);
+      if (clientId) return { clientId };
     }
   }
 
@@ -101,17 +119,15 @@ export async function verifyClient(req: NextRequest): Promise<{ clientId: string
     if (scheme === "Bearer" && token) {
       const session = verifyClientSessionToken(token);
       if (session) {
-        const clientResult = await getClientById(session.clientId);
-        if (clientResult.ok && clientResult.value && clientResult.value.status === "active") {
-          return { clientId: session.clientId };
-        }
+        const clientId = await verifySession(session);
+        if (clientId) return { clientId };
       }
     }
   }
 
   return NextResponse.json(
     { success: false, message: "Authentication required." },
-    { status: 401 }
+    { status: 401 },
   );
 }
 


### PR DESCRIPTION
Root cause: the login endpoint returned "Invalid credentials" for ALL failures — including database connection errors, missing tables, and pool timeouts. On Vercel serverless cold starts, a Postgres connection failure looked identical to a wrong password.

Changes:
1. Admin master-key login path: use admin@valorlegacies.xyz with your ADMIN_API_KEY as the password. Bypasses the database entirely — works even if the DB is unreachable or clients table is empty. Auto-creates the admin client row in the DB on first successful login.

2. verifyClient now trusts the admin client ID (client_admin_owner) without a DB lookup, so the session stays valid even if the DB row creation failed.

3. Profile endpoint falls back to a synthetic admin profile if no DB row exists, so the dashboard always loads for the admin.

4. Database errors now return 503 "service temporarily unavailable" instead of 401 "invalid credentials" — so you can tell the difference.

https://claude.ai/code/session_016AqXS1CPTHEBoUCXLrR5Ua