### PR TITLE
Hide Blog and Resources from dropdown menu

### DIFF
--- a/digital-cathedral/app/components/navbar.tsx
+++ b/digital-cathedral/app/components/navbar.tsx
@@ -35,8 +35,6 @@ function usePortalDomain(): { isPortal: boolean; portalBaseUrl: string } {
 
 const NAV_LINKS = [
   { href: "/", label: "Home" },
-  { href: "/blog", label: "Blog" },
-  { href: "/resources", label: "Resources" },
   { href: "/about", label: "About Us" },
   { href: "/faq", label: "FAQ" },
   { href: "/privacy", label: "Privacy Policy" },


### PR DESCRIPTION
Removes Blog and Resources links from the visible navigation dropdown so leads don't see them. The pages remain accessible to AI crawlers via direct URLs, JSON-LD structured data, and content page footers.

https://claude.ai/code/session_016AqXS1CPTHEBoUCXLrR5Ua