### PR TITLE
feat(mcp): add oracle_reason and oracle_meditate tools to existing MCP

### DIFF
--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -898,6 +898,67 @@ const HANDLERS = {
 
     throw new Error(`Unknown ecosystem action: ${action}`);
   },
+
+  // ─── oracle_reason ───
+  // Cross-pattern abstract reasoning. Wraps src/core/abstract-reasoning.reason()
+  // which returns analogies, metaphors, conceptual bridges, and identity matches
+  // for a source pattern across a cascade of matches.
+  oracle_reason: async (oracle, args) => {
+    const { reason } = require('../core/abstract-reasoning');
+    const { sourcePattern, cascadeMatches } = args || {};
+    if (!sourcePattern || typeof sourcePattern !== 'object') {
+      throw new Error('oracle_reason: sourcePattern is required');
+    }
+    if (!Array.isArray(cascadeMatches)) {
+      throw new Error('oracle_reason: cascadeMatches must be an array');
+    }
+    const report = reason(cascadeMatches, sourcePattern);
+    return {
+      sourcePattern: { name: sourcePattern.name },
+      cascadeCount: cascadeMatches.length,
+      report,
+    };
+  },
+
+  // ─── oracle_meditate ───
+  // Single tick of the auto-improvement loop: discover gaps, propose fills,
+  // validate each. Bounded by maxProposals to prevent runaway compute.
+  // Output is advisory — proposals stay 'pending' unless autoApprove is set
+  // and the global coherency exceeds the autonomous-mode threshold.
+  oracle_meditate: async (oracle, args) => {
+    const { SelfImprovementEngine, APPROVAL_THRESHOLDS } = require('../orchestrator/self-improvement');
+    const { PeriodicTable } = require('../atomic/periodic-table');
+    const maxProposals = (args && Number.isInteger(args.maxProposals)) ? args.maxProposals : 3;
+    const autoApprove = !!(args && args.autoApprove);
+
+    const table = new PeriodicTable();
+    const engine = new SelfImprovementEngine({ maxProposals });
+    const result = await engine.discoverAndPropose({ table });
+
+    let approved = [];
+    if (autoApprove && Array.isArray(result.proposals)) {
+      const mode = engine.getApprovalMode(result.globalCoherency || 0);
+      if (mode === 'autonomous') {
+        for (const p of result.proposals) {
+          const r = engine.approve(p.id, table);
+          if (!r.error) approved.push(p.id);
+        }
+      }
+    }
+
+    return {
+      gapsFound: result.gapsFound || 0,
+      proposalsGenerated: (result.proposals || []).length,
+      proposals: (result.proposals || []).map((p) => ({
+        id: p.id,
+        gap: p.gap,
+        coherency: p.coherency,
+        status: p.status,
+      })),
+      autoApproved: approved,
+      globalCoherency: result.globalCoherency || null,
+    };
+  },
 };
 
 module.exports = { HANDLERS };

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -397,6 +397,34 @@ const TOOLS = [
       },
     },
   },
+
+  // ─── 25. Reason (cross-pattern abstract reasoning) ───
+  {
+    name: 'oracle_reason',
+    description: 'Cross-pattern abstract reasoning. Finds analogies, builds metaphors, identifies conceptual bridges, and detects identity relationships between a source pattern and matches from a cascade. Returns a reasoning report with discovered relationships and confidence per relationship.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sourcePattern: { type: 'object', description: 'The source pattern to reason from (name, optionally tags + code).' },
+        cascadeMatches: { type: 'array', items: { type: 'object' }, description: 'Cascade-matched patterns to reason against. Each entry has at least name + correlation.' },
+      },
+      required: ['sourcePattern', 'cascadeMatches'],
+    },
+  },
+
+  // ─── 26. Meditate (auto-improvement loop, single tick) ───
+  {
+    name: 'oracle_meditate',
+    description: 'Run a single tick of the auto-improvement loop: discover gaps in the periodic table, propose candidate fills, validate each through the structural-safety filter and coherency gates, return the proposals. Output is advisory — proposals stay in `pending` status until explicitly approved. Bounded by maxProposals to prevent runaway compute.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        maxProposals: { type: 'number', description: 'Max proposals to generate this tick (default: 3)', default: 3 },
+        autoApprove: { type: 'boolean', description: 'Auto-approve proposals at or above the autonomous-mode threshold (default: false)', default: false },
+      },
+      required: [],
+    },
+  },
 ];
 
 module.exports = { TOOLS };


### PR DESCRIPTION
Phase 6 of the per-repo MCP rollout. Extends the existing oracle MCP server with two tools that lift internal capabilities into first-class MCP callables, matching the per-repo architecture established in phases 1-5.

Tools added (2):
- oracle_reason   — cross-pattern abstract reasoning. Wraps
                    src/core/abstract-reasoning.reason(). Finds
                    analogies, builds metaphors, identifies conceptual
                    bridges and identity matches between a source
                    pattern and a cascade of matches. Read-only.

- oracle_meditate — single tick of the auto-improvement loop. Wraps SelfImprovementEngine.discoverAndPropose() bounded by maxProposals to prevent runaway compute. Output is advisory: proposals stay 'pending' unless autoApprove is set AND global coherency exceeds the autonomous-mode threshold (= the same gate already used by the orchestrator).

Live smoke test: oracle_reason returns the analogy report for a two-pattern cascade. tools/list returns both new tools.

Why these two specifically: they are the two capabilities the user flagged as wanting to be 'sourceable individually' — abstract reasoning as a tool call, meditation as a tool call. Now they are. A consumer can mount either via MCP without pulling the rest of the toolkit's surface, matching the open-core / per-module-consumability goal.

This completes the MCP rollout. Six MCP servers/extensions now live across the ecosystem:

  1. substrate          (Void-Data-Compressor/mcp)         — 5 tools
  2. reflector          (Reflector-oracle-/mcp)            — 4 tools
  3. witness            (REMEMBRANCE-BLOCKCHAIN/mcp)       — 6 tools
  4. swarm              (REMEMBRANCE-AGENT-Swarm-/mcp)     — 6 tools
  5. dialer             (Remembrance-dialer/mcp)           — 3 tools
  6. oracle (extended)  (remembrance-oracle-toolkit/src/mcp) — 24 + 2

The register/server/sanitize/rate-limit boilerplate is now copy-paste- similar across the five new servers; @remembrance/mcp-base extraction is the natural next step before the count grows further.

https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync