### PR TITLE
chore: capture this session's 6 bug-fix patterns into the debug oracle

### DIFF
--- a/.session-patterns/01-placeholder-detection.js
+++ b/.session-patterns/01-placeholder-detection.js
@@ -1,0 +1,5 @@
+// JS placeholder pattern detection — extend completeness scorer
+// to recognize `{ ... }` blocks (not just bare-line `...`).
+if (/^\s*\.{3}\s*$/m.test(code) || /\{\s*\.{3}\s*\}/.test(code)) {
+  score -= PLACEHOLDER_PENALTY;
+}

--- a/.session-patterns/02-camelcase-regex-expansion.js
+++ b/.session-patterns/02-camelcase-regex-expansion.js
@@ -1,0 +1,5 @@
+// camelCase / snake_case identifier expansion before \b regex matching.
+// Insert spaces at lowercase→uppercase transitions and replace underscores
+// so `clinicalDiagnosis` and `legal_advice` trip identifier-word boundaries.
+const expanded = code.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/_/g, ' ');
+if (patterns.claim.test(expanded)) { /* flag */ }

--- a/.session-patterns/03-reset-epoch-marker.js
+++ b/.session-patterns/03-reset-epoch-marker.js
@@ -1,0 +1,13 @@
+// Epoch marker pattern: after resetSession(), disk-fallback entries older
+// than _resetAt are ignored. Preserves cross-process enforcement (other
+// processes never call resetSession) while honoring local reset semantics.
+let _resetAt = 0;
+function resetSession() { _session = newSession(); _resetAt = Date.now(); }
+function wasSearchRecent() {
+  for (const s of persistedSessions) {
+    const tsMs = new Date(s.lastSearchTimestamp).getTime();
+    if (tsMs < _resetAt) continue;
+    if (Date.now() - tsMs < threshold) return true;
+  }
+  return false;
+}

--- a/.session-patterns/04-legacy-shape-fallback.js
+++ b/.session-patterns/04-legacy-shape-fallback.js
@@ -1,0 +1,7 @@
+// Shape-fallback pattern: when bridging legacy + new field names, return
+// `legacy || new || {}` so callers expecting either shape both work.
+// Example: analyzer migrated `dimensions` → `breakdown`, bridge maps back.
+return {
+  score: coherency.total,
+  dimensions: coherency.dimensions || coherency.breakdown || {},
+};

--- a/.session-patterns/05-uppercase-skip-guard.js
+++ b/.session-patterns/05-uppercase-skip-guard.js
@@ -1,0 +1,7 @@
+// UPPER_CASE skip-guard: re-enabling a code transform that's safe for
+// function params / locals but unsafe for const literals (TS treats
+// `LIMIT === 0` as impossible-comparison). Skip when identifier looks
+// like a SCREAMING_SNAKE_CASE constant.
+const divisorHead = divisorName.split('.')[0];
+if (/^[A-Z_][A-Z0-9_]*$/.test(divisorHead)) return null;
+return patchDivisionGuard(finding, source, program);

--- a/.session-patterns/06-relaxed-assertion-extending-impl.js
+++ b/.session-patterns/06-relaxed-assertion-extending-impl.js
@@ -1,0 +1,6 @@
+// Stale-assertion repair: when impl grows from `'system'` to
+// `'system+ecosystem'` (added ecosystem cross-check), update test to
+// pattern-match the prefix instead of strict-equaling the old value.
+// Captures intent (decided by system, possibly with extra signals)
+// without locking the impl into a single string.
+assert.match(autoInc[0].decidedBy, /^system/);


### PR DESCRIPTION
Each .session-patterns/*.js snippet was fed to `oracle debug capture` and landed in the quantum field as a |superposition⟩ pattern with auto-entangled language variants (python, typescript). They document the reusable shapes behind the 6 fixes in c826dd4:

  01 — JS `{ ... }` placeholder detection
  02 — camelCase / snake_case regex preprocessing
  03 — reset-epoch marker for stale persisted state
  04 — legacy/new field-name fallback for shape bridges
  05 — UPPER_CASE skip-guard for TS-impossible-comparison auto-fixes
  06 — relax strict-equal to prefix-match when impl evolves

Quantum field went 18 → 31 patterns, captures 6 → 12, entanglements 24 → 38.

https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync