### PR TITLE
fix: ecosystem-sweep 404s on case-mismatched GitHub repo paths

### DIFF
--- a/.session-patterns/07-canonical-name-resolution.js
+++ b/.session-patterns/07-canonical-name-resolution.js
@@ -1,0 +1,39 @@
+// Canonical-name resolution pattern for case-mismatched REST paths.
+// GitHub returns 404 (not 301) on sub-paths like /repos/X/y/pulls when the
+// repo casing is off, but redirects on the bare /repos/X/y endpoint. On 404,
+// resolve canonical owner/repo from the redirect target, cache the promise
+// (so concurrent 404s share one roundtrip), then retry the sub-path once.
+
+const _canonicalCache = new Map();
+
+function _resolveCanonical(owner, repo) {
+  const key = `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+  if (_canonicalCache.has(key)) return _canonicalCache.get(key);
+  const p = (async () => {
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { redirect: 'follow' });
+    if (!res.ok) return null;
+    const body = await res.json().catch(() => null);
+    if (!body?.full_name) return null;
+    const [cOwner, cRepo] = body.full_name.split('/');
+    return { owner: cOwner, repo: cRepo };
+  })();
+  _canonicalCache.set(key, p); // cache the promise — dedup concurrent resolves
+  return p;
+}
+
+async function gh(pathname) {
+  let res = await fetch(`https://api.github.com${pathname}`, { redirect: 'follow' });
+  if (res.status === 404) {
+    const m = pathname.match(/^\/repos\/([^/]+)\/([^/?]+)(\/[^?]*)?(\?.*)?$/);
+    if (m) {
+      const [, owner, repo, rest = '', qs = ''] = m;
+      const canonical = await _resolveCanonical(owner, repo);
+      if (canonical && (canonical.owner !== owner || canonical.repo !== repo)) {
+        const fixed = `/repos/${canonical.owner}/${canonical.repo}${rest}${qs}`;
+        res = await fetch(`https://api.github.com${fixed}`, { redirect: 'follow' });
+      }
+    }
+  }
+  if (!res.ok) throw new Error(`${pathname}: ${res.status}`);
+  return res.json();
+}

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -100,6 +100,31 @@
       "services": [
         "docs"
       ]
+    },
+    "MOONS-OF-REMEMBRANCE": {
+      "role": "interface",
+      "description": "Visual moons interface for the Remembrance ecosystem",
+      "language": "typescript",
+      "services": [
+        "ui"
+      ]
+    },
+    "REMEMBRANCE-Interface": {
+      "role": "interface",
+      "description": "Primary web interface for the Remembrance ecosystem",
+      "language": "typescript",
+      "services": [
+        "ui",
+        "api"
+      ]
+    },
+    "remembrance-api-key-plugger": {
+      "role": "integration",
+      "description": "API key management for ecosystem integrations",
+      "language": "javascript",
+      "services": [
+        "key-manager"
+      ]
     }
   },
   "patternStats": {

--- a/src/core/ecosystem-sweep.js
+++ b/src/core/ecosystem-sweep.js
@@ -21,11 +21,56 @@ const ECOSYSTEM_FILE = path.resolve(__dirname, '..', '..', 'ecosystem.json');
 const OWNER = process.env.ECOSYSTEM_OWNER || 'crackedcoder5th';
 const TOKEN = process.env.ECOSYSTEM_PAT || process.env.GITHUB_TOKEN;
 
+// Canonical repo-name cache. GitHub's REST returns 404 (not 301) on
+// case-mismatched sub-paths like `/repos/X/Y/pulls`, but the base
+// `/repos/X/Y` endpoint DOES redirect on case mismatch. We resolve once
+// per repo via that base endpoint, follow the redirect, read `full_name`
+// for the canonical casing, and rewrite subsequent paths.
+const _canonicalCache = new Map();
+
+function _ghHeaders(extra = {}) {
+  return { Authorization: `Bearer ${TOKEN}`, Accept: 'application/vnd.github+json', 'User-Agent': 'ecosystem-sweep', ...extra };
+}
+
+function _resolveCanonical(owner, repo) {
+  const key = `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+  // Cache the *promise* so concurrent 404s from probeRepo's Promise.all
+  // share a single resolution roundtrip instead of each kicking off their own.
+  if (_canonicalCache.has(key)) return _canonicalCache.get(key);
+  const p = (async () => {
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+      headers: _ghHeaders(),
+      redirect: 'follow',
+    });
+    if (!res.ok) return null;
+    const body = await res.json().catch(() => null);
+    if (!body?.full_name) return null;
+    const [cOwner, cRepo] = body.full_name.split('/');
+    return { owner: cOwner, repo: cRepo };
+  })();
+  _canonicalCache.set(key, p);
+  return p;
+}
+
 async function gh(pathname, opts = {}) {
-  const res = await fetch(`https://api.github.com${pathname}`, {
-    headers: { Authorization: `Bearer ${TOKEN}`, Accept: 'application/vnd.github+json', 'User-Agent': 'ecosystem-sweep', ...(opts.headers || {}) },
+  const doFetch = (p) => fetch(`https://api.github.com${p}`, {
+    headers: _ghHeaders(opts.headers || {}),
+    redirect: 'follow',
     ...opts,
   });
+  let res = await doFetch(pathname);
+  // 404 on a sub-path may be a case-mismatch — resolve canonical and retry once.
+  if (res.status === 404) {
+    const m = pathname.match(/^\/repos\/([^/]+)\/([^/?]+)(\/[^?]*)?(\?.*)?$/);
+    if (m) {
+      const [, oldOwner, oldRepo, rest = '', qs = ''] = m;
+      const canonical = await _resolveCanonical(oldOwner, oldRepo);
+      if (canonical && (canonical.owner !== oldOwner || canonical.repo !== oldRepo)) {
+        const fixed = `/repos/${canonical.owner}/${canonical.repo}${rest}${qs}`;
+        res = await doFetch(fixed);
+      }
+    }
+  }
   if (!res.ok) throw new Error(`${pathname}: ${res.status} ${await res.text().catch(() => '')}`);
   return res.json();
 }
@@ -34,14 +79,25 @@ function loadPeers() {
   if (fs.existsSync(ECOSYSTEM_FILE)) {
     try {
       const eco = JSON.parse(fs.readFileSync(ECOSYSTEM_FILE, 'utf-8'));
-      const peers = (eco.services || []).map(s => s.repo).filter(Boolean);
+      // Support two shapes:
+      //   { repos: { "Repo-Name": {...} } }     ← current canonical shape
+      //   { services: [{ repo: "name" }, ...] } ← older list shape
+      let peers = [];
+      if (eco.repos && typeof eco.repos === 'object') {
+        peers = Object.keys(eco.repos).filter(name => name && name !== 'remembrance-oracle-toolkit');
+      }
+      if (!peers.length && Array.isArray(eco.services)) {
+        peers = eco.services.map(s => s.repo).filter(Boolean);
+      }
       if (peers.length) return peers;
     } catch {}
   }
+  // Fallback uses canonical GitHub casing so the case-resolution roundtrip
+  // is avoided on a fresh checkout. _resolveCanonical still covers any drift.
   return [
-    'void-data-compressor', 'moons-of-remembrance', 'remembrance-agent-swarm-',
-    'remembrance-interface', 'remembrance-blockchain', 'reflector-oracle-',
-    'remembrance-dialer', 'remembrance-api-key-plugger',
+    'Void-Data-Compressor', 'MOONS-OF-REMEMBRANCE', 'REMEMBRANCE-AGENT-Swarm-',
+    'REMEMBRANCE-Interface', 'REMEMBRANCE-BLOCKCHAIN', 'Reflector-oracle-',
+    'Remembrance-dialer', 'remembrance-api-key-plugger',
   ];
 }
 
@@ -74,9 +130,12 @@ async function tryAutoMergeReflector(repo, pr) {
   if (failed.length > 0) return { merged: false, reason: `${failed.length} check(s) failing` };
   const incomplete = checks.check_runs.filter(c => c.status !== 'completed');
   if (incomplete.length > 0) return { merged: false, reason: `${incomplete.length} check(s) pending` };
-  const res = await fetch(`https://api.github.com/repos/${OWNER}/${repo}/pulls/${pr.number}/merge`, {
+  // Resolve canonical name (cached) so the merge PUT doesn't 404 on case mismatch.
+  const canonical = (await _resolveCanonical(OWNER, repo)) || { owner: OWNER, repo };
+  const res = await fetch(`https://api.github.com/repos/${canonical.owner}/${canonical.repo}/pulls/${pr.number}/merge`, {
     method: 'PUT',
-    headers: { Authorization: `Bearer ${TOKEN}`, Accept: 'application/vnd.github+json', 'Content-Type': 'application/json' },
+    headers: _ghHeaders({ 'Content-Type': 'application/json' }),
+    redirect: 'follow',
     body: JSON.stringify({ merge_method: 'squash', commit_title: `auto-merge: ${pr.title}` }),
   });
   if (res.ok) return { merged: true, reason: 'merged', at: new Date().toISOString() };
@@ -139,4 +198,4 @@ if (require.main === module) {
     .catch(e => { console.error(`# Sweep Failed\n\n${e.message}`); process.exit(1); });
 }
 
-module.exports = { runSweep, toMarkdown, probeRepo, loadPeers, tryAutoMergeReflector };
+module.exports = { runSweep, toMarkdown, probeRepo, loadPeers, tryAutoMergeReflector, _resolveCanonical, _canonicalCache };

--- a/tests/ecosystem-sweep.test.js
+++ b/tests/ecosystem-sweep.test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+/**
+ * Verifies the case-mismatch fallback in `gh()`: on 404, the helper resolves
+ * the canonical owner/repo casing from `/repos/X/Y` (which redirects) and
+ * retries the original sub-path. Without the fix, a lowercase repo name
+ * against a mixed-case GitHub repo returns 404 with no recovery.
+ */
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('ecosystem-sweep — canonical repo casing recovery', () => {
+  let originalFetch;
+  let calls;
+  let sweep;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../src/core/ecosystem-sweep')];
+    process.env.ECOSYSTEM_PAT = 'test-token';
+    process.env.ECOSYSTEM_OWNER = 'Crackedcoder5TH';
+    sweep = require('../src/core/ecosystem-sweep');
+    sweep._canonicalCache.clear();
+    calls = [];
+    originalFetch = global.fetch;
+  });
+
+  function installFakeFetch(routes) {
+    global.fetch = async (url, opts = {}) => {
+      calls.push({ url, method: opts.method || 'GET' });
+      const u = new URL(url);
+      const handler = routes[u.pathname + u.search] || routes[u.pathname];
+      if (!handler) return { ok: false, status: 404, json: async () => ({}), text: async () => 'no route' };
+      return handler();
+    };
+  }
+
+  function restoreFetch() { global.fetch = originalFetch; }
+
+  it('returns data without retry when the path is already canonical', async () => {
+    installFakeFetch({
+      '/repos/Crackedcoder5TH/Void-Data-Compressor/pulls?state=open&per_page=50': () => ({
+        ok: true, status: 200,
+        json: async () => [{ number: 22, title: 'docs', head: { ref: 'feat', sha: 'abc' } }],
+      }),
+      '/repos/Crackedcoder5TH/Void-Data-Compressor/commits?per_page=1': () => ({
+        ok: true, status: 200,
+        json: async () => [{ commit: { author: { date: new Date().toISOString() } } }],
+      }),
+      '/repos/Crackedcoder5TH/Void-Data-Compressor/actions/runs?per_page=5': () => ({
+        ok: true, status: 200,
+        json: async () => ({ workflow_runs: [{ conclusion: 'success' }] }),
+      }),
+    });
+    try {
+      const r = await sweep.probeRepo('Void-Data-Compressor');
+      assert.equal(r.status === 'error', false, `unexpected error: ${r.error}`);
+      // No canonical resolve roundtrip should have happened.
+      const resolveCalls = calls.filter(c => /^\/repos\/[^/]+\/[^/]+$/.test(new URL(c.url).pathname));
+      assert.equal(resolveCalls.length, 0, 'should not have resolved canonical name when path works');
+    } finally { restoreFetch(); }
+  });
+
+  it('recovers from 404 by resolving canonical casing and retrying once', async () => {
+    let resolved = false;
+    installFakeFetch({
+      // First call: lowercase name 404s
+      '/repos/Crackedcoder5TH/void-data-compressor/pulls?state=open&per_page=50': () => ({
+        ok: false, status: 404, json: async () => ({}), text: async () => '{"message":"Not Found"}',
+      }),
+      '/repos/Crackedcoder5TH/void-data-compressor/commits?per_page=1': () => ({
+        ok: false, status: 404, json: async () => ({}), text: async () => '{"message":"Not Found"}',
+      }),
+      '/repos/Crackedcoder5TH/void-data-compressor/actions/runs?per_page=5': () => ({
+        ok: false, status: 404, json: async () => ({}), text: async () => '{"message":"Not Found"}',
+      }),
+      // Resolution endpoint: returns canonical full_name
+      '/repos/Crackedcoder5TH/void-data-compressor': () => {
+        resolved = true;
+        return {
+          ok: true, status: 200,
+          json: async () => ({ full_name: 'Crackedcoder5TH/Void-Data-Compressor' }),
+        };
+      },
+      // Retry with canonical casing succeeds
+      '/repos/Crackedcoder5TH/Void-Data-Compressor/pulls?state=open&per_page=50': () => ({
+        ok: true, status: 200,
+        json: async () => [],
+      }),
+      '/repos/Crackedcoder5TH/Void-Data-Compressor/commits?per_page=1': () => ({
+        ok: true, status: 200,
+        json: async () => [{ commit: { author: { date: new Date().toISOString() } } }],
+      }),
+      '/repos/Crackedcoder5TH/Void-Data-Compressor/actions/runs?per_page=5': () => ({
+        ok: true, status: 200,
+        json: async () => ({ workflow_runs: [{ conclusion: 'success' }] }),
+      }),
+    });
+    try {
+      const r = await sweep.probeRepo('void-data-compressor');
+      assert.notEqual(r.status, 'error', `unexpected error after retry: ${r.error}`);
+      assert.equal(resolved, true, 'should have hit the canonical resolution endpoint');
+    } finally { restoreFetch(); }
+  });
+
+  it('caches canonical resolution — second call to same repo skips the resolve roundtrip', async () => {
+    let resolveCount = 0;
+    installFakeFetch({
+      '/repos/Crackedcoder5TH/void-data-compressor/pulls?state=open&per_page=50': () => ({
+        ok: false, status: 404, json: async () => ({}), text: async () => 'nf',
+      }),
+      '/repos/Crackedcoder5TH/void-data-compressor/commits?per_page=1': () => ({
+        ok: false, status: 404, json: async () => ({}), text: async () => 'nf',
+      }),
+      '/repos/Crackedcoder5TH/void-data-compressor/actions/runs?per_page=5': () => ({
+        ok: false, status: 404, json: async () => ({}), text: async () => 'nf',
+      }),
+      '/repos/Crackedcoder5TH/void-data-compressor': () => {
+        resolveCount++;
+        return { ok: true, status: 200, json: async () => ({ full_name: 'Crackedcoder5TH/Void-Data-Compressor' }) };
+      },
+      '/repos/Crackedcoder5TH/Void-Data-Compressor/pulls?state=open&per_page=50': () => ({ ok: true, status: 200, json: async () => [] }),
+      '/repos/Crackedcoder5TH/Void-Data-Compressor/commits?per_page=1': () => ({ ok: true, status: 200, json: async () => [] }),
+      '/repos/Crackedcoder5TH/Void-Data-Compressor/actions/runs?per_page=5': () => ({ ok: true, status: 200, json: async () => ({ workflow_runs: [] }) }),
+    });
+    try {
+      await sweep.probeRepo('void-data-compressor');
+      await sweep.probeRepo('void-data-compressor');
+      assert.equal(resolveCount, 1, 'canonical resolution should be cached across probes');
+    } finally { restoreFetch(); }
+  });
+
+  it('gives up gracefully when canonical lookup also fails (truly missing repo)', async () => {
+    installFakeFetch({
+      '/repos/Crackedcoder5TH/no-such-repo/pulls?state=open&per_page=50': () => ({
+        ok: false, status: 404, json: async () => ({}), text: async () => 'nf',
+      }),
+      '/repos/Crackedcoder5TH/no-such-repo': () => ({
+        ok: false, status: 404, json: async () => ({}), text: async () => 'nf',
+      }),
+      // commits + runs use .catch in probeRepo so they're allowed to fail
+    });
+    try {
+      const r = await sweep.probeRepo('no-such-repo');
+      assert.equal(r.status, 'error');
+      assert.match(r.error, /404/);
+    } finally { restoreFetch(); }
+  });
+});


### PR DESCRIPTION
Root cause was two bugs working together:

1. `loadPeers()` read `eco.services` but ecosystem.json holds peers under `eco.repos`, so the canonical-cased names there were silently skipped and the hard-coded lowercase fallback list won every time. The fix reads `repos` (current shape) with the `services` array as legacy fallback, and excludes the host repo (`remembrance-oracle-toolkit`) from the peer list.

2. The hard-coded fallback used lowercase names that don't match the actual repos on GitHub (`void-data-compressor` vs. `Void-Data-Compressor`, etc.). GitHub's REST returns 404 — not 301 — on case-mismatched sub-paths like `/repos/X/Y/pulls`, so `fetch`'s built-in redirect-follow can't recover. The fix is two-fold:

   - Update the fallback to the canonical mixed-case names so a fresh clone with no `ecosystem.json` still works.
   - Have `gh()` detect 404 on `/repos/{owner}/{repo}/...` paths, fall back to the base `/repos/{owner}/{repo}` endpoint (which DOES redirect on case mismatch), read the canonical `full_name` from the redirect target, and retry the original sub-path with the corrected casing. Promise-cache the resolution so concurrent probes (Promise.all in probeRepo) dedup to a single roundtrip.

`tryAutoMergeReflector` also went through raw `fetch`; it now resolves canonical casing before the PUT so auto-merges don't 404 either.

ecosystem.json gains entries for MOONS-OF-REMEMBRANCE, REMEMBRANCE-Interface, and remembrance-api-key-plugger (previously absent — the sweep was under-covering the ecosystem).

Added 4 new tests in tests/ecosystem-sweep.test.js exercising the canonical-already, 404→retry, cached-resolve, and truly-missing paths.

Full suite: 4381/4381 pass. Oracle covenant SEALED 15/15, I_AM 0.913. Pattern captured into the debug quantum field as 36fdf56b228747e8.

https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync