### PR TITLE
chore(npm): add a package-name bin so `npx remembrance-oracle-toolkit…

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "bin": {
     "remembrance-oracle": "src/cli.js",
     "oracle": "src/cli.js",
-    "reflector": "bin/reflector"
+    "reflector": "bin/reflector",
+    "remembrance-oracle-toolkit": "src/cli.js"
   },
   "files": [
     "src/",


### PR DESCRIPTION
…` resolves

The bin map had remembrance-oracle / oracle / reflector but no entry matching the package name, so `npx remembrance-oracle-toolkit` had no default bin to run. Add it (-> src/cli.js). npm publish --dry-run is otherwise clean: 408 files, zero dependencies, valid bins — publish-ready.

https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync