### PR TITLE
Lean hostable LRE field-server (fixes Railway "failed to respond")

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "dashboard": "node src/cli.js dashboard",
     "cloud": "node src/cli.js cloud start",
     "mcp": "node src/cli.js mcp",
+    "field-server": "node scripts/field-server.js",
     "seed": "node src/cli.js seed",
     "analytics": "node src/cli.js analytics --json",
     "postinstall": "node -e \"try{require('fs').mkdirSync('.remembrance',{recursive:true})}catch{}\"",

--- a/packages/field-tool/README.md
+++ b/packages/field-tool/README.md
@@ -1,76 +1,93 @@
-# remembrance-field
+# @crackedcoder5th/remembrance-field
 
-The **Remembrance Field tool** as a tiny, zero-dependency npm package: the
-canonical 256-D waveform encoder, cosine **coherency** ("do these mean the
-same thing?"), and a best-effort client for the shared **Remembrance Field**.
+The **Remembrance Field tool** as a tiny, zero-dependency npm package. It works
+**standalone**, and — when pointed at **your Void compressor** — uses your
+collected substrate (the 77k+ pattern library) to score with real resonance
+and to (with your consent) contribute new patterns to the canonical library.
 
 The encoder is byte-identical to Void's `to_waveform.py` and the oracle
-toolkit's `code-to-waveform.js` (cross-language parity contracts C-49/C-50),
-so a string encodes to the same waveform in Python, JS, and here.
+toolkit's `code-to-waveform.js` (parity contracts C-49/C-50), so a string
+encodes to the same waveform in Python, JS, and here.
 
 ## Install
 
 ```bash
-npm install remembrance-field        # library
-npm install -g remembrance-field     # CLI
-# or run without installing:
-npx remembrance-field coherency "hello" "hullo"
+npm install @crackedcoder5th/remembrance-field        # library
+npm install -g @crackedcoder5th/remembrance-field     # CLI
+npx @crackedcoder5th/remembrance-field coherency "hello" "hullo"
 ```
 
-Requires Node >= 18 (uses the built-in `fetch`). No other dependencies.
+Requires Node >= 18 (built-in `fetch`). No other dependencies.
 
-## Library
+## Standalone — works with no network
 
 ```js
-const { toWaveform, coherency, coherencyOf, Field } = require('remembrance-field');
+const { toWaveform, coherency, coherencyOf } = require('@crackedcoder5th/remembrance-field');
 
-const wf = toWaveform('function add(a, b) { return a + b; }'); // Float64Array(256), values in [0,1]
-
-// "do these mean the same thing?" — cosine in [0,1]
-const score = coherencyOf(
-  'function add(a, b) { return a + b; }',
-  'def add(a, b):\n    return a + b'
-);
-
-// contribute a reading to a running Remembrance Field (best-effort, never throws)
-const field = new Field(); // http://127.0.0.1:7787/mcp by default
-const res = await field.contribute({ coherence: score, source: 'my-app:compare' });
+toWaveform('function add(a, b) { return a + b; }');     // Float64Array(256), [0,1]
+coherencyOf('function add(a,b){return a+b}', 'def add(a, b): return a + b'); // cosine in [0,1]
 ```
-
-### API
-
-| Export | Description |
-|---|---|
-| `toWaveform(text) -> Float64Array(256)` | Encode any text into the native 256-D waveform (`[0,1]`). |
-| `coherency(a, b) -> number` | Cosine similarity of two waveforms (`[-1,1]`, `0` if either is empty). |
-| `coherencyOf(textA, textB) -> number` | Convenience: encode both, then `coherency`. |
-| `new Field({ url?, token?, timeoutMs? })` | Field client. Defaults from `REMEMBRANCE_FIELD_URL` / `REMEMBRANCE_FIELD_TOKEN`. |
-| `field.contribute({ coherence, source, cost? })` | Contribute one observation. Best-effort: returns a result object, never throws. |
-| `field.call(action, args)` | Low-level call to the field tool for any supported action. |
-
-## CLI
 
 ```bash
-remembrance-field encode "some text"          # -> dim=256 mean=… energy=…
-remembrance-field encode @file.js --json      # -> full 256-number array
-remembrance-field coherency "a" "b"           # -> 0.xxxxxx
-remembrance-field coherency @a.js @b.py        # inputs may be @file
-remembrance-field contribute --coherence 0.91 --source my-app --cost 1
+remembrance-field encode "some text"      # dim=256 mean=… energy=…
+remembrance-field coherency "a" "b"       # 0.xxxxxx   (inputs may be @file)
 ```
 
-Inputs are literal strings, or `@path` to read a file.
+## Connected — enhanced by your Void compressor
 
-## The Field
+Point the tool at your running Void instance and it uses your collected data
+for accuracy instead of a bare pairwise cosine. Everything degrades gracefully
+when Void is offline.
 
-`contribute` posts a JSON-RPC `tools/call` to the field endpoint's `field`
-tool (`action: "contribute"`), the same contract every Remembrance producer
-uses. With no field running, `contribute` simply returns `{ ok: false }` —
-the coherency math above works fully offline regardless.
+```bash
+export REMEMBRANCE_VOID_URL=http://127.0.0.1:8080   # your Void api.py
+export REMEMBRANCE_AGENT_ID=my-agent-v1             # stable submitter id
 
-Environment:
+remembrance-field score @mypattern.js               # substrate-backed coherence
+```
 
-- `REMEMBRANCE_FIELD_URL` — field endpoint (default `http://127.0.0.1:7787/mcp`)
-- `REMEMBRANCE_FIELD_TOKEN` — bearer token (sent only to https or loopback hosts)
+```js
+const { VoidClient } = require('@crackedcoder5th/remembrance-field');
+const void_ = new VoidClient();                       // REMEMBRANCE_VOID_URL or 127.0.0.1:8080
+const r = await void_.coherence('some code');         // { ok, body:{ coherence, ... } }
+```
+
+### Contributing a pattern — always asks first
+
+`submit` scores your pattern against the substrate, then **asks whether you
+want to add it to the canonical pattern library**. Nothing is contributed
+unless you say yes (the default is **no**, and a non-interactive shell never
+contributes unless you pass `--yes`).
+
+```bash
+remembrance-field submit @mypattern.js --name debounce-timeout --language javascript
+# Pattern "debounce-timeout" — 412 chars, substrate coherence 0.83
+# Add this pattern to the canonical pattern library? [y/N]
+```
+
+Flags: `--yes`/`-y` (contribute without prompting), `--no` (never), `--language`,
+`--tags a,b`, `--description "…"`. Submissions go to Void's public
+`POST /patterns/submit` and return an accept/reject decision, coherence, and tier.
+
+## The Field (shared conserved scalar)
+
+```bash
+remembrance-field contribute --coherence 0.91 --source my-app
+```
+
+```js
+const { Field } = require('@crackedcoder5th/remembrance-field');
+await new Field().contribute({ coherence: 0.91, source: 'my-app' }); // best-effort, never throws
+```
+
+## Environment
+
+| Var | Purpose | Default |
+|---|---|---|
+| `REMEMBRANCE_VOID_URL` | your Void compressor (scoring + submission) | `http://127.0.0.1:8080` |
+| `REMEMBRANCE_AGENT_ID` | stable id stamped on pattern submissions | (required to submit) |
+| `REMEMBRANCE_FIELD_URL` | field endpoint for `contribute` | `http://127.0.0.1:7787/mcp` |
+| `REMEMBRANCE_FIELD_TOKEN` | field bearer token (https/loopback only) | — |
 
 ## License
 

--- a/packages/field-tool/README.md
+++ b/packages/field-tool/README.md
@@ -1,0 +1,77 @@
+# remembrance-field
+
+The **Remembrance Field tool** as a tiny, zero-dependency npm package: the
+canonical 256-D waveform encoder, cosine **coherency** ("do these mean the
+same thing?"), and a best-effort client for the shared **Remembrance Field**.
+
+The encoder is byte-identical to Void's `to_waveform.py` and the oracle
+toolkit's `code-to-waveform.js` (cross-language parity contracts C-49/C-50),
+so a string encodes to the same waveform in Python, JS, and here.
+
+## Install
+
+```bash
+npm install remembrance-field        # library
+npm install -g remembrance-field     # CLI
+# or run without installing:
+npx remembrance-field coherency "hello" "hullo"
+```
+
+Requires Node >= 18 (uses the built-in `fetch`). No other dependencies.
+
+## Library
+
+```js
+const { toWaveform, coherency, coherencyOf, Field } = require('remembrance-field');
+
+const wf = toWaveform('function add(a, b) { return a + b; }'); // Float64Array(256), values in [0,1]
+
+// "do these mean the same thing?" — cosine in [0,1]
+const score = coherencyOf(
+  'function add(a, b) { return a + b; }',
+  'def add(a, b):\n    return a + b'
+);
+
+// contribute a reading to a running Remembrance Field (best-effort, never throws)
+const field = new Field(); // http://127.0.0.1:7787/mcp by default
+const res = await field.contribute({ coherence: score, source: 'my-app:compare' });
+```
+
+### API
+
+| Export | Description |
+|---|---|
+| `toWaveform(text) -> Float64Array(256)` | Encode any text into the native 256-D waveform (`[0,1]`). |
+| `coherency(a, b) -> number` | Cosine similarity of two waveforms (`[-1,1]`, `0` if either is empty). |
+| `coherencyOf(textA, textB) -> number` | Convenience: encode both, then `coherency`. |
+| `new Field({ url?, token?, timeoutMs? })` | Field client. Defaults from `REMEMBRANCE_FIELD_URL` / `REMEMBRANCE_FIELD_TOKEN`. |
+| `field.contribute({ coherence, source, cost? })` | Contribute one observation. Best-effort: returns a result object, never throws. |
+| `field.call(action, args)` | Low-level call to the field tool for any supported action. |
+
+## CLI
+
+```bash
+remembrance-field encode "some text"          # -> dim=256 mean=… energy=…
+remembrance-field encode @file.js --json      # -> full 256-number array
+remembrance-field coherency "a" "b"           # -> 0.xxxxxx
+remembrance-field coherency @a.js @b.py        # inputs may be @file
+remembrance-field contribute --coherence 0.91 --source my-app --cost 1
+```
+
+Inputs are literal strings, or `@path` to read a file.
+
+## The Field
+
+`contribute` posts a JSON-RPC `tools/call` to the field endpoint's `field`
+tool (`action: "contribute"`), the same contract every Remembrance producer
+uses. With no field running, `contribute` simply returns `{ ok: false }` —
+the coherency math above works fully offline regardless.
+
+Environment:
+
+- `REMEMBRANCE_FIELD_URL` — field endpoint (default `http://127.0.0.1:7787/mcp`)
+- `REMEMBRANCE_FIELD_TOKEN` — bearer token (sent only to https or loopback hosts)
+
+## License
+
+MIT

--- a/packages/field-tool/bin/cli.js
+++ b/packages/field-tool/bin/cli.js
@@ -2,22 +2,28 @@
 'use strict';
 
 const fs = require('fs');
-const { toWaveform, coherency, coherencyOf, Field, DIM } = require('../src/index');
+const { toWaveform, coherency, coherencyOf, Field, VoidClient, confirm, DIM } = require('../src/index');
 
 const HELP = `remembrance-field — the Remembrance Field tool
 
-Usage:
+Standalone (no network):
   remembrance-field encode <text|@file> [--json]
-      Encode input into the 256-D waveform. Prints a summary; --json prints the full array.
-
+      Encode input into the 256-D waveform. Summary by default; --json = full array.
   remembrance-field coherency <a|@file> <b|@file>
-      Cosine coherency in [0,1] between two inputs ("do these mean the same thing?").
+      Cosine coherency in [0,1] between two inputs.
 
+Connected to your Void compressor (REMEMBRANCE_VOID_URL, default http://127.0.0.1:8080):
+  remembrance-field score <text|@file>
+      Score input against your collected substrate (real resonance, not a bare cosine).
+  remembrance-field submit <code|@file> --name <name> [--language <l>] [--tags a,b] [--description <d>]
+      Score the pattern, then ASK whether to add it to the canonical pattern library.
+      --yes / --no skip the prompt; otherwise you are prompted (defaults to NO).
+
+Field (shared conserved scalar):
   remembrance-field contribute --coherence <0..1> --source <label> [--cost <n>] [--url <u>] [--token <t>]
-      Contribute one observation to a running Remembrance Field (best-effort).
 
+Env: REMEMBRANCE_FIELD_URL, REMEMBRANCE_FIELD_TOKEN, REMEMBRANCE_VOID_URL, REMEMBRANCE_AGENT_ID.
 Inputs: a literal string, or @path to read a file.
-Env: REMEMBRANCE_FIELD_URL (default http://127.0.0.1:7787/mcp), REMEMBRANCE_FIELD_TOKEN.
 `;
 
 function readInput(s) {
@@ -29,9 +35,22 @@ function parseFlags(args) {
   const flags = {}; const pos = [];
   for (let i = 0; i < args.length; i++) {
     if (args[i].startsWith('--')) { flags[args[i].slice(2)] = (args[i + 1] && !args[i + 1].startsWith('--')) ? args[++i] : true; }
+    else if (args[i] === '-y') flags.yes = true;
     else pos.push(args[i]);
   }
   return { flags, pos };
+}
+
+function voidCoherence(res) {
+  // /coherence returns a coherence score under one of a few keys depending on version.
+  if (!res || res.ok === false) return null;
+  const b = res.body;
+  if (b && typeof b === 'object') {
+    for (const k of ['coherence', 'coherency', 'score', 'unified']) {
+      if (typeof b[k] === 'number') return b[k];
+    }
+  }
+  return null;
 }
 
 async function main() {
@@ -43,15 +62,53 @@ async function main() {
     const wf = toWaveform(readInput(pos[0]));
     if (flags.json) { process.stdout.write(JSON.stringify(Array.from(wf)) + '\n'); return; }
     let mean = 0, energy = 0; for (const v of wf) { mean += v; energy += v * v; }
-    mean /= DIM; energy = Math.sqrt(energy);
-    process.stdout.write(`dim=${DIM} mean=${mean.toFixed(4)} energy=${energy.toFixed(3)}\n`);
+    process.stdout.write(`dim=${DIM} mean=${(mean / DIM).toFixed(4)} energy=${Math.sqrt(energy).toFixed(3)}\n`);
     return;
   }
 
   if (cmd === 'coherency' || cmd === 'cohere') {
     if (pos.length < 2) { process.stderr.write('coherency needs two inputs\n'); process.exit(2); }
-    const c = coherencyOf(readInput(pos[0]), readInput(pos[1]));
-    process.stdout.write(c.toFixed(6) + '\n');
+    process.stdout.write(coherencyOf(readInput(pos[0]), readInput(pos[1])).toFixed(6) + '\n');
+    return;
+  }
+
+  if (cmd === 'score') {
+    const text = readInput(pos[0]);
+    const void_ = new VoidClient({ url: typeof flags.url === 'string' ? flags.url : undefined });
+    const res = await void_.coherence(text);
+    const c = voidCoherence(res);
+    if (c == null) {
+      process.stderr.write(`Void not reachable at ${void_.url} — substrate scoring needs a running Void compressor.\n` +
+        `Set REMEMBRANCE_VOID_URL, or use \`coherency\` for offline pairwise comparison.\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`substrate coherence = ${c.toFixed(6)}  (via ${void_.url})\n`);
+    return;
+  }
+
+  if (cmd === 'submit') {
+    const code = readInput(pos[0]);
+    const name = typeof flags.name === 'string' ? flags.name : '';
+    if (!name) { process.stderr.write('submit needs --name <name>\n'); process.exit(2); }
+    const void_ = new VoidClient({ url: typeof flags.url === 'string' ? flags.url : undefined });
+
+    // Show the substrate score first so the user can make an informed choice.
+    const scored = voidCoherence(await void_.coherence(code));
+    process.stdout.write(`Pattern "${name}" — ${code.length} chars` +
+      (scored != null ? `, substrate coherence ${scored.toFixed(4)}` : ', (Void offline — score unavailable)') + '\n');
+
+    const force = flags.yes ? true : (flags.no ? false : undefined);
+    const yes = await confirm('Add this pattern to the canonical pattern library?', { force, defaultValue: false });
+    if (!yes) { process.stdout.write('Skipped — pattern was NOT contributed.\n'); return; }
+
+    const res = await void_.submitPattern({
+      name, code,
+      language: typeof flags.language === 'string' ? flags.language : undefined,
+      tags: typeof flags.tags === 'string' ? flags.tags.split(',').map((t) => t.trim()).filter(Boolean) : undefined,
+      description: typeof flags.description === 'string' ? flags.description : undefined,
+    });
+    if (res.ok === false) { process.stderr.write('Submission failed: ' + (res.error || JSON.stringify(res.body)) + '\n'); process.exit(1); }
+    process.stdout.write('Submitted: ' + JSON.stringify(res.body) + '\n');
     return;
   }
 

--- a/packages/field-tool/bin/cli.js
+++ b/packages/field-tool/bin/cli.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const { toWaveform, coherency, coherencyOf, Field, DIM } = require('../src/index');
+
+const HELP = `remembrance-field — the Remembrance Field tool
+
+Usage:
+  remembrance-field encode <text|@file> [--json]
+      Encode input into the 256-D waveform. Prints a summary; --json prints the full array.
+
+  remembrance-field coherency <a|@file> <b|@file>
+      Cosine coherency in [0,1] between two inputs ("do these mean the same thing?").
+
+  remembrance-field contribute --coherence <0..1> --source <label> [--cost <n>] [--url <u>] [--token <t>]
+      Contribute one observation to a running Remembrance Field (best-effort).
+
+Inputs: a literal string, or @path to read a file.
+Env: REMEMBRANCE_FIELD_URL (default http://127.0.0.1:7787/mcp), REMEMBRANCE_FIELD_TOKEN.
+`;
+
+function readInput(s) {
+  if (typeof s === 'string' && s.startsWith('@')) return fs.readFileSync(s.slice(1), 'utf8');
+  return s == null ? '' : String(s);
+}
+
+function parseFlags(args) {
+  const flags = {}; const pos = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--')) { flags[args[i].slice(2)] = (args[i + 1] && !args[i + 1].startsWith('--')) ? args[++i] : true; }
+    else pos.push(args[i]);
+  }
+  return { flags, pos };
+}
+
+async function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') { process.stdout.write(HELP); return; }
+  const { flags, pos } = parseFlags(rest);
+
+  if (cmd === 'encode') {
+    const wf = toWaveform(readInput(pos[0]));
+    if (flags.json) { process.stdout.write(JSON.stringify(Array.from(wf)) + '\n'); return; }
+    let mean = 0, energy = 0; for (const v of wf) { mean += v; energy += v * v; }
+    mean /= DIM; energy = Math.sqrt(energy);
+    process.stdout.write(`dim=${DIM} mean=${mean.toFixed(4)} energy=${energy.toFixed(3)}\n`);
+    return;
+  }
+
+  if (cmd === 'coherency' || cmd === 'cohere') {
+    if (pos.length < 2) { process.stderr.write('coherency needs two inputs\n'); process.exit(2); }
+    const c = coherencyOf(readInput(pos[0]), readInput(pos[1]));
+    process.stdout.write(c.toFixed(6) + '\n');
+    return;
+  }
+
+  if (cmd === 'contribute') {
+    const field = new Field({ url: typeof flags.url === 'string' ? flags.url : undefined, token: typeof flags.token === 'string' ? flags.token : undefined });
+    const res = await field.contribute({ coherence: Number(flags.coherence), source: flags.source, cost: flags.cost != null ? Number(flags.cost) : 1.0 });
+    process.stdout.write(JSON.stringify(res) + '\n');
+    process.exit(res.ok ? 0 : 1);
+  }
+
+  process.stderr.write(`unknown command: ${cmd}\n\n` + HELP);
+  process.exit(2);
+}
+
+main().catch((e) => { process.stderr.write('error: ' + ((e && e.message) || e) + '\n'); process.exit(1); });

--- a/packages/field-tool/package.json
+++ b/packages/field-tool/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "remembrance-field",
+  "version": "0.1.0",
+  "description": "The Remembrance Field tool — canonical 256-D waveform encoder + cosine coherency + a best-effort client for the shared Remembrance Field. Zero dependencies.",
+  "type": "commonjs",
+  "main": "src/index.js",
+  "bin": {
+    "remembrance-field": "bin/cli.js"
+  },
+  "files": [
+    "src",
+    "bin",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "remembrance",
+    "coherency",
+    "waveform",
+    "field",
+    "encoder",
+    "cosine"
+  ],
+  "license": "MIT"
+}

--- a/packages/field-tool/package.json
+++ b/packages/field-tool/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "remembrance-field",
-  "version": "0.1.0",
-  "description": "The Remembrance Field tool — canonical 256-D waveform encoder + cosine coherency + a best-effort client for the shared Remembrance Field. Zero dependencies.",
+  "name": "@crackedcoder5th/remembrance-field",
+  "version": "0.2.0",
+  "description": "The Remembrance Field tool — canonical 256-D waveform encoder + cosine coherency, standalone, with an optional connection to your Void compressor for substrate-backed scoring and consent-gated pattern contribution. Zero dependencies.",
   "type": "commonjs",
   "main": "src/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "remembrance-field": "bin/cli.js"
   },

--- a/packages/field-tool/src/field.js
+++ b/packages/field-tool/src/field.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * field.js — best-effort client for the shared Remembrance Field.
+ *
+ * Mirrors Void's `field_contribute.py`: a JSON-RPC 2.0 `tools/call` to the
+ * field endpoint's `field` tool. Contributions are best-effort — a down or
+ * slow field never throws; the caller gets a result object instead.
+ *
+ * Contract (default http://127.0.0.1:7787/mcp):
+ *   { jsonrpc:"2.0", id:1, method:"tools/call",
+ *     params:{ name:"field", arguments:{ action:"contribute",
+ *              coherence:<0..1>, source:"<label>", cost:<number> } } }
+ *   Auth: if a token is configured, Authorization: Bearer <token> — sent only
+ *   to https or loopback hosts, never cleartext to a remote host.
+ */
+
+const DEFAULT_FIELD_URL = 'http://127.0.0.1:7787/mcp';
+
+class Field {
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.url]   field endpoint (env REMEMBRANCE_FIELD_URL)
+   * @param {string} [opts.token] bearer token (env REMEMBRANCE_FIELD_TOKEN)
+   * @param {number} [opts.timeoutMs=1500]
+   */
+  constructor({ url, token, timeoutMs = 1500 } = {}) {
+    this.url = url || process.env.REMEMBRANCE_FIELD_URL || DEFAULT_FIELD_URL;
+    this.token = (token || process.env.REMEMBRANCE_FIELD_TOKEN || '').trim();
+    this.timeoutMs = timeoutMs;
+  }
+
+  /** Low-level: call the field tool with any action. Never throws. */
+  async call(action, args = {}) {
+    let u;
+    try { u = new URL(this.url); } catch { return { ok: false, error: 'invalid field url' }; }
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return { ok: false, error: 'field url must be http(s)' };
+
+    const headers = { 'content-type': 'application/json' };
+    const loopback = ['127.0.0.1', 'localhost', '::1'].includes(u.hostname);
+    if (this.token && (u.protocol === 'https:' || loopback)) headers.authorization = 'Bearer ' + this.token;
+
+    const body = JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name: 'field', arguments: { action, ...args } },
+    });
+
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(this.url, { method: 'POST', headers, body, signal: ctrl.signal });
+      const text = await res.text();
+      let json = null; try { json = JSON.parse(text); } catch { /* non-json */ }
+      return { ok: res.ok, status: res.status, body: json != null ? json : text };
+    } catch (e) {
+      return { ok: false, error: String((e && e.message) || e) };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Contribute one observation to the field. Best-effort; never throws.
+   * @param {{coherence:number, source:string, cost?:number}} obs
+   */
+  contribute({ coherence, source, cost = 1.0 } = {}) {
+    if (typeof source !== 'string' || !source) {
+      return Promise.resolve({ ok: false, error: 'source (non-empty string) is required' });
+    }
+    let c = Number(coherence);
+    if (!Number.isFinite(c)) c = 0;
+    c = Math.max(0, Math.min(1, c));
+    let k = Number(cost);
+    if (!Number.isFinite(k)) k = 1.0;
+    return this.call('contribute', { coherence: c, source, cost: k });
+  }
+}
+
+module.exports = { Field, DEFAULT_FIELD_URL };

--- a/packages/field-tool/src/index.js
+++ b/packages/field-tool/src/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * remembrance-field — the Remembrance Field tool.
+ *
+ *   const { toWaveform, coherency, coherencyOf, Field } = require('remembrance-field');
+ *
+ *   const score = coherencyOf('function add(a,b){return a+b}', 'def add(a, b): return a + b');
+ *   const field = new Field();                       // http://127.0.0.1:7787/mcp by default
+ *   await field.contribute({ coherence: score, source: 'my-app:compare' });
+ */
+
+const { DIM, toWaveform, coherency, coherencyOf } = require('./waveform');
+const { Field, DEFAULT_FIELD_URL } = require('./field');
+
+module.exports = { DIM, toWaveform, coherency, coherencyOf, Field, DEFAULT_FIELD_URL };

--- a/packages/field-tool/src/index.js
+++ b/packages/field-tool/src/index.js
@@ -1,16 +1,31 @@
 'use strict';
 
 /**
- * remembrance-field — the Remembrance Field tool.
+ * @crackedcoder5th/remembrance-field — the Remembrance Field tool.
  *
- *   const { toWaveform, coherency, coherencyOf, Field } = require('remembrance-field');
+ * Standalone (offline):
+ *   const { toWaveform, coherency, coherencyOf } = require('@crackedcoder5th/remembrance-field');
+ *   const score = coherencyOf('foo', 'foo bar');
  *
- *   const score = coherencyOf('function add(a,b){return a+b}', 'def add(a, b): return a + b');
- *   const field = new Field();                       // http://127.0.0.1:7787/mcp by default
- *   await field.contribute({ coherence: score, source: 'my-app:compare' });
+ * Connected (uses YOUR Void compressor's collected substrate for accuracy):
+ *   const { VoidClient } = require('@crackedcoder5th/remembrance-field');
+ *   const void_ = new VoidClient();                       // http://127.0.0.1:8080 by default
+ *   const r = await void_.coherence('some code');         // substrate-backed score
+ *   await void_.submitPattern({ name, code, language });  // contribute (get consent first!)
+ *
+ * Field (shared conserved scalar):
+ *   const { Field } = require('@crackedcoder5th/remembrance-field');
+ *   await new Field().contribute({ coherence: score, source: 'my-app' });
  */
 
 const { DIM, toWaveform, coherency, coherencyOf } = require('./waveform');
 const { Field, DEFAULT_FIELD_URL } = require('./field');
+const { VoidClient, DEFAULT_VOID_URL } = require('./void');
+const { confirm } = require('./prompt');
 
-module.exports = { DIM, toWaveform, coherency, coherencyOf, Field, DEFAULT_FIELD_URL };
+module.exports = {
+  DIM, toWaveform, coherency, coherencyOf,
+  Field, DEFAULT_FIELD_URL,
+  VoidClient, DEFAULT_VOID_URL,
+  confirm,
+};

--- a/packages/field-tool/src/prompt.js
+++ b/packages/field-tool/src/prompt.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const readline = require('node:readline');
+
+/**
+ * Ask a yes/no question. Resolution order:
+ *   force === true   -> resolve true   (e.g. --yes)
+ *   force === false  -> resolve false  (e.g. --no)
+ *   non-interactive  -> resolve defaultValue (privacy-safe; default false)
+ *   interactive TTY  -> actually prompt the user
+ *
+ * @param {string} question
+ * @param {{force?:boolean, defaultValue?:boolean}} [opts]
+ * @returns {Promise<boolean>}
+ */
+function confirm(question, { force, defaultValue = false } = {}) {
+  if (force === true) return Promise.resolve(true);
+  if (force === false) return Promise.resolve(false);
+  if (!process.stdin.isTTY) return Promise.resolve(defaultValue);
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`${question} ${defaultValue ? '[Y/n]' : '[y/N]'} `, (ans) => {
+      rl.close();
+      const a = String(ans || '').trim().toLowerCase();
+      if (a === '') return resolve(defaultValue);
+      resolve(a === 'y' || a === 'yes');
+    });
+  });
+}
+
+module.exports = { confirm };

--- a/packages/field-tool/src/void.js
+++ b/packages/field-tool/src/void.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * void.js — optional connection to YOUR Void compressor / data hub.
+ *
+ * Everything in this package works standalone (offline coherency). When a
+ * Void instance is reachable, these calls use your collected substrate — the
+ * 77k+ pattern library — to score with real resonance instead of a bare
+ * pairwise cosine, and to (optionally, with consent) contribute new patterns
+ * to the canonical library.
+ *
+ * Targets Void's public api.py (default http://127.0.0.1:8080):
+ *   POST /coherence        { text }                  -> { coherence, ... }
+ *   POST /patterns/submit  { agent_id, name, code }  -> { accepted, coherence, tier, reasons }
+ *   GET  /health
+ *
+ * Best-effort: a down/slow Void never throws — calls return a result object.
+ */
+
+const DEFAULT_VOID_URL = 'http://127.0.0.1:8080';
+
+class VoidClient {
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.url]      Void base URL (env REMEMBRANCE_VOID_URL)
+   * @param {string} [opts.agentId]  stable submitter id (env REMEMBRANCE_AGENT_ID)
+   * @param {number} [opts.timeoutMs=4000]
+   */
+  constructor({ url, agentId, timeoutMs = 4000 } = {}) {
+    this.url = (url || process.env.REMEMBRANCE_VOID_URL || DEFAULT_VOID_URL).replace(/\/+$/, '');
+    this.agentId = (agentId || process.env.REMEMBRANCE_AGENT_ID || '').trim();
+    this.timeoutMs = timeoutMs;
+  }
+
+  async _req(method, pathname, payload) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    try {
+      const opts = { method, headers: {}, signal: ctrl.signal };
+      if (payload !== undefined) { opts.headers['content-type'] = 'application/json'; opts.body = JSON.stringify(payload); }
+      const res = await fetch(this.url + pathname, opts);
+      const text = await res.text();
+      let json = null; try { json = JSON.parse(text); } catch { /* non-json */ }
+      return { ok: res.ok, status: res.status, body: json != null ? json : text };
+    } catch (e) {
+      return { ok: false, error: String((e && e.message) || e) };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Is a Void instance reachable? */
+  async available() {
+    const r = await this._req('GET', '/health');
+    return !!r.ok;
+  }
+
+  /**
+   * Score text against your collected substrate (real resonance, not a bare
+   * pairwise cosine). Returns the raw Void response, or { ok:false } offline.
+   */
+  coherence(text) {
+    return this._req('POST', '/coherence', { text: text == null ? '' : String(text) });
+  }
+
+  /**
+   * Submit a pattern to the canonical pattern library. NOTE: the CLI gates
+   * this behind an explicit consent prompt — call this directly only when the
+   * caller has already obtained consent.
+   * @param {{name:string, code:string, language?:string, tags?:string[], description?:string, agentId?:string}} p
+   */
+  submitPattern(p = {}) {
+    const agent_id = (p.agentId || this.agentId || '').trim();
+    if (!agent_id) return Promise.resolve({ ok: false, error: 'agent_id required — set REMEMBRANCE_AGENT_ID or pass agentId' });
+    if (!p.name || !String(p.name).trim()) return Promise.resolve({ ok: false, error: 'name required' });
+    if (typeof p.code !== 'string' || p.code.length < 20) return Promise.resolve({ ok: false, error: 'code must be a string of at least 20 characters' });
+    if (p.code.length > 200000) return Promise.resolve({ ok: false, error: 'code exceeds the 200KB limit' });
+    const payload = { agent_id, name: String(p.name).trim(), code: p.code };
+    if (p.language) payload.language = p.language;
+    if (Array.isArray(p.tags)) payload.tags = p.tags;
+    if (p.description) payload.description = p.description;
+    return this._req('POST', '/patterns/submit', payload);
+  }
+}
+
+module.exports = { VoidClient, DEFAULT_VOID_URL };

--- a/packages/field-tool/src/waveform.js
+++ b/packages/field-tool/src/waveform.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * waveform.js — the canonical Remembrance encoder, self-contained.
+ *
+ * Byte-identical to Void's `to_waveform.py` and the oracle toolkit's
+ * `src/core/code-to-waveform.js` (cross-language parity contracts C-49/C-50):
+ *   1. UTF-8 encode the input to bytes
+ *   2. Linear-interpolate (np.interp) to exactly 256 samples
+ *   3. Min-max normalize to [0, 1]; degenerate input -> flat 0.5
+ *
+ * Pure, deterministic, side-effect-free. No dependencies.
+ */
+
+const DIM = 256;
+
+/** np.interp for xp = [0..n-1], x = linspace(0, n-1, targetLen). */
+function _linearInterp(fp, targetLen) {
+  const n = fp.length;
+  const out = new Float64Array(targetLen);
+  if (n === 0) return out;
+  if (n === 1) { out.fill(fp[0]); return out; }
+  const step = (n - 1) / (targetLen - 1);
+  for (let i = 0; i < targetLen; i++) {
+    const x = i * step;
+    const j = Math.floor(x);
+    if (j >= n - 1) out[i] = fp[n - 1];
+    else { const t = x - j; out[i] = fp[j] + t * (fp[j + 1] - fp[j]); }
+  }
+  return out;
+}
+
+/**
+ * Encode arbitrary text into the native 256-D float64 waveform (values in
+ * [0, 1]). Empty input -> all zeros. Flat/constant input -> all 0.5.
+ * @param {string} text
+ * @returns {Float64Array} length 256
+ */
+function toWaveform(text) {
+  if (typeof text !== 'string' || text.length === 0) return new Float64Array(DIM);
+  const bytes = Buffer.from(text, 'utf8');
+  const fp = new Float64Array(bytes.length);
+  for (let i = 0; i < bytes.length; i++) fp[i] = bytes[i];
+
+  const wf = _linearInterp(fp, DIM);
+  let lo = wf[0], hi = wf[0];
+  for (let i = 1; i < DIM; i++) { if (wf[i] < lo) lo = wf[i]; if (wf[i] > hi) hi = wf[i]; }
+  if (hi - lo < 1e-10) { const flat = new Float64Array(DIM); flat.fill(0.5); return flat; }
+  const norm = new Float64Array(DIM);
+  for (let i = 0; i < DIM; i++) norm[i] = (wf[i] - lo) / (hi - lo);
+  return norm;
+}
+
+/**
+ * Cosine similarity of two waveforms — the universal "do these mean the same
+ * thing?" primitive. Returns a scalar in [-1, 1] (typically [0, 1]); 0 when
+ * either vector has no magnitude.
+ * @param {ArrayLike<number>} a
+ * @param {ArrayLike<number>} b
+ * @returns {number}
+ */
+function coherency(a, b) {
+  const n = Math.min(a.length, b.length);
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < n; i++) {
+    const x = a[i] || 0, y = b[i] || 0;
+    dot += x * y; na += x * x; nb += y * y;
+  }
+  const da = Math.sqrt(na), db = Math.sqrt(nb);
+  if (da < 1e-12 || db < 1e-12) return 0;
+  return dot / (da * db);
+}
+
+/** Convenience: cosine coherency between two raw texts. */
+function coherencyOf(textA, textB) {
+  return coherency(toWaveform(textA), toWaveform(textB));
+}
+
+module.exports = { DIM, toWaveform, coherency, coherencyOf };

--- a/packages/field-tool/test/field.test.js
+++ b/packages/field-tool/test/field.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { toWaveform, coherency, coherencyOf, Field, DIM } = require('../src/index');
+
+test('toWaveform returns a 256-D vector in [0,1]', () => {
+  const wf = toWaveform('hello world');
+  assert.strictEqual(wf.length, DIM);
+  for (const v of wf) assert.ok(v >= 0 && v <= 1);
+});
+
+test('empty input -> all zeros', () => {
+  const wf = toWaveform('');
+  assert.strictEqual(wf.length, DIM);
+  assert.ok(wf.every((v) => v === 0));
+});
+
+test('coherency of identical inputs is 1', () => {
+  assert.ok(Math.abs(coherencyOf('abc123', 'abc123') - 1) < 1e-12);
+});
+
+test('coherency is symmetric and in range', () => {
+  const a = 'function add(a,b){return a+b}';
+  const b = 'def add(a, b):\n    return a + b';
+  const ab = coherencyOf(a, b), ba = coherencyOf(b, a);
+  assert.ok(Math.abs(ab - ba) < 1e-12);
+  assert.ok(ab >= -1 && ab <= 1);
+});
+
+test('coherency against the zero vector is 0', () => {
+  assert.strictEqual(coherency(toWaveform('x'), new Float64Array(DIM)), 0);
+});
+
+test('Field.contribute requires a source and never throws', async () => {
+  const field = new Field({ url: 'http://127.0.0.1:9' /* unused: no source */ });
+  const bad = await field.contribute({ coherence: 0.9 });
+  assert.strictEqual(bad.ok, false);
+});
+
+test('Field.contribute is best-effort against an unreachable field', async () => {
+  const field = new Field({ url: 'http://127.0.0.1:1/mcp', timeoutMs: 300 });
+  const res = await field.contribute({ coherence: 0.9, source: 'test:offline' });
+  assert.strictEqual(res.ok, false); // unreachable -> error, but did not throw
+});

--- a/packages/field-tool/test/void.test.js
+++ b/packages/field-tool/test/void.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { VoidClient, confirm } = require('../src/index');
+
+test('VoidClient.coherence is best-effort against an unreachable Void', async () => {
+  const v = new VoidClient({ url: 'http://127.0.0.1:1', timeoutMs: 300 });
+  const res = await v.coherence('some text');
+  assert.strictEqual(res.ok, false); // unreachable -> error object, never throws
+});
+
+test('submitPattern requires agent_id', async () => {
+  const v = new VoidClient({ url: 'http://127.0.0.1:1', agentId: '', timeoutMs: 300 });
+  const res = await v.submitPattern({ name: 'x', code: 'a'.repeat(40) });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.error, /agent_id/);
+});
+
+test('submitPattern enforces a minimum code length', async () => {
+  const v = new VoidClient({ url: 'http://127.0.0.1:1', agentId: 'tester', timeoutMs: 300 });
+  const res = await v.submitPattern({ name: 'x', code: 'short' });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.error, /20 characters/);
+});
+
+test('confirm honors --yes / --no without prompting', async () => {
+  assert.strictEqual(await confirm('q', { force: true }), true);
+  assert.strictEqual(await confirm('q', { force: false }), false);
+});
+
+test('confirm defaults to NO when non-interactive (privacy-safe)', async () => {
+  // In the test runner stdin is not a TTY, so this resolves the default.
+  assert.strictEqual(await confirm('q', { defaultValue: false }), false);
+});

--- a/scripts/field-server.js
+++ b/scripts/field-server.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Lean Living Remembrance Engine HTTP server.
+ *
+ * Starts ONLY the field endpoint — no full-oracle bootstrap, no autoSync — so
+ * it is reliable to host (Railway / Fly / a VPS). Binds 0.0.0.0:$PORT (the
+ * platform-injected port), persists to $ENTROPY_PATH (point this at a volume
+ * in production), and optionally requires a bearer token via $FIELD_TOKEN.
+ *
+ * Wire contract (matches Void's field_contribute.py and the swarm field bridge):
+ *   POST /mcp  { "jsonrpc":"2.0","id":1,"method":"tools/call",
+ *                "params":{"name":"field","arguments":{
+ *                  "action":"contribute","coherence":0..1,"source":"...","cost":1}}}
+ *   GET  /     -> { ok, field: <state> }   (health check / quick peek)
+ */
+
+const http = require('node:http');
+const { contribute, peekField } = require('../src/core/field-coupling');
+
+const PORT = parseInt(process.env.PORT, 10) || 7787;
+const HOST = process.env.HOST || '0.0.0.0';
+const TOKEN = (process.env.FIELD_TOKEN || process.env.REMEMBRANCE_FIELD_TOKEN || '').trim();
+
+function send(res, code, obj) {
+  const body = JSON.stringify(obj);
+  res.writeHead(code, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) });
+  res.end(body);
+}
+
+const server = http.createServer((req, res) => {
+  // Health / quick peek — also what a browser hitting the URL will see.
+  if (req.method === 'GET') {
+    let field = null;
+    try { field = peekField(); } catch (_e) { /* best-effort */ }
+    return send(res, 200, { ok: true, service: 'remembrance-field', field });
+  }
+  if (req.method !== 'POST') return send(res, 405, { error: 'use POST (contribute) or GET (health)' });
+
+  if (TOKEN && (req.headers['authorization'] || '') !== 'Bearer ' + TOKEN) {
+    return send(res, 401, { error: 'unauthorized' });
+  }
+
+  let raw = '';
+  req.on('data', (c) => { raw += c; if (raw.length > 1e6) req.destroy(); });
+  req.on('end', () => {
+    let msg;
+    try { msg = JSON.parse(raw || '{}'); } catch { return send(res, 400, { error: 'invalid JSON' }); }
+    const id = msg.id != null ? msg.id : 1;
+    const args = (msg.params && msg.params.arguments) || msg.arguments || {};
+    const action = args.action || 'contribute';
+    try {
+      if (action === 'read' || action === 'peek' || action === 'state') {
+        return send(res, 200, { jsonrpc: '2.0', id, result: peekField() });
+      }
+      const coherence = Number(args.coherence);
+      const source = typeof args.source === 'string' ? args.source.trim() : '';
+      if (!Number.isFinite(coherence) || !source) {
+        return send(res, 400, { jsonrpc: '2.0', id, error: { message: 'coherence (number) and source (non-empty string) are required' } });
+      }
+      contribute({ cost: Number(args.cost) || 1, coherence: Math.max(0, Math.min(1, coherence)), source });
+      return send(res, 200, { jsonrpc: '2.0', id, result: peekField() });
+    } catch (e) {
+      return send(res, 500, { jsonrpc: '2.0', id, error: { message: String((e && e.message) || e) } });
+    }
+  });
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`[field-server] Living Remembrance Engine on ${HOST}:${PORT}` +
+    (TOKEN ? ' (bearer auth on)' : ' (no auth — set FIELD_TOKEN)') +
+    ` | persist: ${process.env.ENTROPY_PATH || '.remembrance/entropy.json (ephemeral without a volume)'}`);
+});


### PR DESCRIPTION
Adds `scripts/field-server.js` + `npm run field-server` — a lean HTTP server that starts **only** the Living Remembrance Engine field endpoint (no full-oracle bootstrap / autoSync), which is why `oracle mcp --http` was failing to respond on Railway.

- Binds `0.0.0.0:$PORT` (platform-injected port)
- Persists to `$ENTROPY_PATH` (point at a volume)
- Optional bearer auth via `$FIELD_TOKEN`
- Same JSON-RPC `field/contribute` contract Void + the swarm post to; `GET /` is a health/peek

Verified locally: health 200, 401 without token, contribute updates + persists state.

**Railway start command becomes:** `node scripts/field-server.js`

https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync)_