### PR TITLE
field-tool: "Connect to your ecosystem" docs + .env.example

### DIFF
--- a/packages/field-tool/.env.example
+++ b/packages/field-tool/.env.example
@@ -1,0 +1,13 @@
+# @crackedcoder5th/remembrance-field — connect to your ecosystem.
+# Copy to .env and fill in your hosted endpoints. ALL optional: the tool works
+# fully offline (encode / coherency / coherencyOf) with none of these set.
+
+# Hosted Living Remembrance Engine (the oracle field-server). Field.contribute() posts here.
+REMEMBRANCE_FIELD_URL=
+# Bearer token for the field (sent only to https or loopback hosts).
+REMEMBRANCE_FIELD_TOKEN=
+
+# Your Void compressor / data hub — substrate-backed scoring + pattern submission.
+REMEMBRANCE_VOID_URL=
+# Stable identifier stamped on pattern submissions (required only for `submit`).
+REMEMBRANCE_AGENT_ID=

--- a/packages/field-tool/README.md
+++ b/packages/field-tool/README.md
@@ -80,6 +80,30 @@ const { Field } = require('@crackedcoder5th/remembrance-field');
 await new Field().contribute({ coherence: 0.91, source: 'my-app' }); // best-effort, never throws
 ```
 
+## Connect to your ecosystem
+
+By default everything runs against `localhost`. To use **your** hosted services
+(e.g. the field on Railway, your Void compressor), set these where the tool runs
+— your app's `.env`, your shell, or CI secrets. Copy [`.env.example`](./.env.example)
+to `.env` and fill in:
+
+```bash
+# Hosted Living Remembrance Engine (the oracle field-server)
+REMEMBRANCE_FIELD_URL=https://<your-host>/mcp
+REMEMBRANCE_FIELD_TOKEN=<your FIELD_TOKEN>
+# Your Void compressor / data hub
+REMEMBRANCE_VOID_URL=https://<your-void-host>
+REMEMBRANCE_AGENT_ID=<your-stable-agent-id>     # only needed to submit patterns
+```
+
+What each unlocks:
+- **`REMEMBRANCE_FIELD_URL` (+ `_TOKEN`)** → `Field.contribute()` / `contribute` feed your shared field.
+- **`REMEMBRANCE_VOID_URL`** → `score` / `VoidClient.coherence()` use your collected substrate (real resonance, not a bare cosine).
+- **`REMEMBRANCE_AGENT_ID`** → stamped on `submit` (consent-gated pattern contributions).
+
+`encode` / `coherency` / `coherencyOf` always work **offline** regardless — the
+connection only adds the substrate-backed and field features.
+
 ## Environment
 
 | Var | Purpose | Default |

--- a/packages/field-tool/package.json
+++ b/packages/field-tool/package.json
@@ -13,7 +13,8 @@
   "files": [
     "src",
     "bin",
-    "README.md"
+    "README.md",
+    ".env.example"
   ],
   "scripts": {
     "test": "node --test test/*.test.js"


### PR DESCRIPTION
Documents how to point the field tool at hosted services and ships a fill-in template.

- README: new **"Connect to your ecosystem"** section with a copy-paste env block and what each var unlocks (field contribute / substrate scoring / pattern submit).
- New **`.env.example`** (added to the published `files`) — copy to `.env` and fill in your hosted endpoints.

Offline `encode`/`coherency` need none of them. Tests 12/12; `.env.example` confirmed in the npm tarball.

https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync)_