### PR TITLE
chore: sync package-lock.json for field-tool workspace (fixes Railway npm ci)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       "bin": {
         "oracle": "src/cli.js",
         "reflector": "bin/reflector",
-        "remembrance-oracle": "src/cli.js"
+        "remembrance-oracle": "src/cli.js",
+        "remembrance-oracle-toolkit": "src/cli.js"
       },
       "engines": {
         "node": ">=22.0.0",
@@ -60,6 +61,10 @@
       "resolved": "packages/shared",
       "link": true
     },
+    "node_modules/@crackedcoder5th/remembrance-field": {
+      "resolved": "packages/field-tool",
+      "link": true
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -72,6 +77,17 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "packages/field-tool": {
+      "name": "@crackedcoder5th/remembrance-field",
+      "version": "0.2.0",
+      "license": "MIT",
+      "bin": {
+        "remembrance-field": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/shared": {


### PR DESCRIPTION
Fixes the Railway build failure (`npm ci` → "Missing: @crackedcoder5th/remembrance-field@0.2.0 from lock file").

Adding `packages/field-tool` made it an npm **workspace** member, but `package-lock.json` wasn't regenerated. Ran `npm install --package-lock-only` to sync the lock file (minimal diff, +17/−1; no dependency downloads). `npm ci` will now find the workspace package.

https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2ihQsGRZ9b5rSDWMDjync)_