### PR TITLE
cathedral: fix field reachability (URL normalize) + hybrid site-conte…

### DIFF
--- a/digital-cathedral/app/lib/database.ts
+++ b/digital-cathedral/app/lib/database.ts
@@ -8,6 +8,7 @@
  * All exported functions are async (return Promise<Result<...>>).
  */
 import path from "path";
+import { getRecord, storeRecord } from "./valor/remembrance-bridge";
 
 // --- Result type for typed error handling ---
 type Result<T, E = Error> = { ok: true; value: T } | { ok: false; error: E };
@@ -1333,11 +1334,26 @@ export async function deleteLeadById(leadId: string): Promise<Result<{ deleted: 
   return getAdapter().deleteLeadById(leadId);
 }
 
+// HYBRID: site content (free-form copy — a clean fit) lives in the SUBSTRATE
+// when the field is configured; relational/transactional data stays on the
+// adapter (Postgres). A stable id ('site:<key>') makes the store an upsert by
+// key. Falls back to the adapter when no field URL is set.
+const SUBSTRATE_FIELD = (process.env.REMEMBRANCE_FIELD_URL || "").trim();
+const siteRecordId = (key: string): string => "site:" + key;
+
 export async function getDbSiteContent(key: string): Promise<Result<string | null, string>> {
+  if (SUBSTRATE_FIELD) {
+    const rec = await getRecord(siteRecordId(key));
+    return Ok(rec ? rec.content : null);
+  }
   return getAdapter().getSiteContent(key);
 }
 
 export async function setDbSiteContent(key: string, value: string): Promise<Result<void, string>> {
+  if (SUBSTRATE_FIELD) {
+    const r = await storeRecord({ id: siteRecordId(key), name: siteRecordId(key), content: value, tags: ["site-content"] });
+    return r && r.ok ? Ok(undefined) : Err("substrate store failed (field unreachable?)");
+  }
   return getAdapter().setSiteContent(key, value);
 }
 

--- a/digital-cathedral/app/lib/valor/remembrance-bridge.ts
+++ b/digital-cathedral/app/lib/valor/remembrance-bridge.ts
@@ -24,7 +24,12 @@ const DEFAULT_FIELD_URL = "http://127.0.0.1:7787/mcp";
 const TIMEOUT_MS = 1500;
 
 function fieldUrl(): string {
-  return (process.env.REMEMBRANCE_FIELD_URL || DEFAULT_FIELD_URL).trim();
+  let url = (process.env.REMEMBRANCE_FIELD_URL || DEFAULT_FIELD_URL).trim().replace(/\/+$/, "");
+  // The bridge speaks JSON-RPC to the MCP endpoint. Accept either the base URL
+  // (the interface's convention — REMEMBRANCE_FIELD_URL=https://host) or the full
+  // /mcp endpoint, and normalize to /mcp so a single env value works for both apps.
+  if (!/\/mcp$/i.test(url)) url += "/mcp";
+  return url;
 }
 
 function authToken(): string {
@@ -47,17 +52,14 @@ function isLoopbackOrHttps(url: string): boolean {
  * null on any failure (network, timeout, non-2xx, malformed JSON).
  * Never throws.
  */
-async function mcpCall<T = unknown>(action: string, args: Record<string, unknown> = {}): Promise<T | null> {
+async function mcpTool<T = unknown>(toolName: string, args: Record<string, unknown> = {}): Promise<T | null> {
   const url = fieldUrl();
   if (!isLoopbackOrHttps(url) && !url.startsWith("http://")) return null;
   const body = {
     jsonrpc: "2.0",
     id: 1,
     method: "tools/call",
-    params: {
-      name: "field",
-      arguments: { action, ...args },
-    },
+    params: { name: toolName, arguments: args },
   };
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   const token = authToken();
@@ -92,6 +94,11 @@ async function mcpCall<T = unknown>(action: string, args: Record<string, unknown
   }
 }
 
+// Field-dynamics calls use the legacy "field" tool with an action argument.
+async function mcpCall<T = unknown>(action: string, args: Record<string, unknown> = {}): Promise<T | null> {
+  return mcpTool<T>("field", { action, ...args });
+}
+
 // ── Field state read ─────────────────────────────────────────────────
 
 export interface FieldState {
@@ -107,6 +114,40 @@ export interface FieldState {
 
 export async function peekField(opts: { includeSources?: boolean } = {}): Promise<FieldState | null> {
   return mcpCall<FieldState>("state", { includeSources: opts.includeSources === true });
+}
+
+// ── Substrate data store ─────────────────────────────────────────────
+// The cathedral's content lives in the field's legacy store (coherence-scored,
+// resonance-searchable) and is recalled retro-causally. A stable id makes store
+// an upsert-by-key. Best-effort like the rest — null/[] when the field is down.
+
+export interface SubstrateRecord {
+  id: string;
+  name: string;
+  content: string;
+  tags?: string[];
+  coherence?: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** Upsert a record. Pass a stable `id` to overwrite by key; omit for a content-hash id. */
+export async function storeRecord(
+  rec: { id?: string; name: string; content: string; tags?: string[]; author?: string; meta?: Record<string, unknown> },
+): Promise<{ ok: boolean; id?: string } | null> {
+  return mcpTool<{ ok: boolean; id?: string }>("legacy", { action: "store", ...rec });
+}
+
+/** Fetch a record by id (null if absent or the field is unreachable). */
+export async function getRecord(id: string): Promise<SubstrateRecord | null> {
+  const r = await mcpTool<{ ok: boolean; legacy: SubstrateRecord | null }>("legacy", { action: "get", id });
+  return r && r.ok && r.legacy ? r.legacy : null;
+}
+
+/** Retro-causal recall — the resonant slices for a query. */
+export async function recall(query: string, k = 6): Promise<Array<SubstrateRecord & { score: number }>> {
+  const r = await mcpTool<{ ok: boolean; slices: Array<SubstrateRecord & { score: number }> }>("recall", { query, k });
+  return r && r.ok && r.slices ? r.slices : [];
 }
 
 // ── Cost / benefit contributions ─────────────────────────────────────


### PR DESCRIPTION
…nt store

Reachability — the bridge POSTs JSON-RPC and needs the /mcp endpoint, but the interface convention is the BASE url (REMEMBRANCE_FIELD_URL=https://host). Same env var, two formats — so one value couldn't satisfy both, and the cathedral read "unreachable" even with the URL set. Fix: fieldUrl() now accepts either and normalizes to /mcp, so one base url works for both apps.

Bridge data layer — generalized the MCP call (mcpTool(name,args); mcpCall stays a thin "field" wrapper) so the bridge can reach the legacy + recall tools, and added storeRecord / getRecord / recall.

Hybrid (per recommendation) — site content (free-form copy, a clean fit) now lives in the SUBSTRATE when REMEMBRANCE_FIELD_URL is set; a stable id ('site:<key>') makes the store an upsert-by-key. Relational/transactional data (leads, purchases, auth, documents' numeric ids) stays on Postgres. Falls back to the adapter when no field is configured.

Verified: typecheck clean; store('site:veteranStory')->coherence 0.915, get returns the content over /mcp.


Claude-Session: https://claude.ai/code/session_01XeuEWbZGDznSTjSePTMC6L