### PR TITLE
feat(gates): plain-English readiness checks on the field-server + cat…

### DIFF
--- a/digital-cathedral/app/api/field/health/route.ts
+++ b/digital-cathedral/app/api/field/health/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { fieldEndpoint, peekField } from "@/app/lib/valor/remembrance-bridge";
+
+export const dynamic = "force-dynamic";
+
+type Check = { name: string; ok: boolean; level: "critical" | "warn" | "info"; detail: string; fix?: string };
+
+// Field-connection preflight for the cathedral — SAME path and shape as the
+// interface (/api/field/health), so "open /api/field/health on either app" is
+// the one rule to remember. Every failing check carries a plain-English fix.
+// Read-only; the token value is never exposed (only presence + length).
+export async function GET() {
+  const rawUrl = (process.env.REMEMBRANCE_FIELD_URL || "").trim();
+  const token = (process.env.REMEMBRANCE_FIELD_TOKEN || "").trim();
+  const hasScheme = /^https?:\/\//i.test(rawUrl);
+  const endpoint = fieldEndpoint();
+  const state = await peekField({ includeSources: true }).catch(() => null);
+  const reachable = !!state;
+
+  const checks: Check[] = [];
+
+  checks.push(rawUrl
+    ? { name: "Field URL is set", ok: true, level: "critical", detail: `REMEMBRANCE_FIELD_URL = ${rawUrl}` }
+    : {
+        name: "Field URL is set", ok: false, level: "critical",
+        detail: "REMEMBRANCE_FIELD_URL is not set — the cathedral falls back to localhost, which does not exist on Vercel.",
+        fix: "In Vercel → the cathedral project → Settings → Environment Variables, add REMEMBRANCE_FIELD_URL = https://<your-field-server-host>, then Redeploy.",
+      });
+
+  if (rawUrl) {
+    checks.push(hasScheme
+      ? { name: "URL includes https://", ok: true, level: "info", detail: `scheme present — calling ${endpoint}` }
+      : {
+          name: "URL includes https://", ok: false, level: "warn",
+          detail: `The value "${rawUrl}" has no http(s):// — it is auto-treated as ${endpoint}.`,
+          fix: "Set REMEMBRANCE_FIELD_URL to the full https:// URL to be explicit, then redeploy.",
+        });
+  }
+
+  checks.push(reachable
+    ? { name: "Field answers", ok: true, level: "critical", detail: `connected — coherence ${state!.coherence}, ${state!.updateCount} updates` }
+    : {
+        name: "Field answers", ok: false, level: "critical",
+        detail: "The field did not answer over /mcp.",
+        fix: rawUrl
+          ? "Open your field-server URL in a browser — you should see JSON. If it works there but not here, redeploy this app so the env value is applied."
+          : "Set the Field URL first (above), then redeploy.",
+      });
+
+  checks.push(token
+    ? { name: "Write token is set", ok: true, level: "info", detail: `token present (${token.length} chars) — substrate writes and dual-oracle validation are enabled` }
+    : {
+        name: "Write token is set", ok: false, level: "warn",
+        detail: "No REMEMBRANCE_FIELD_TOKEN — reading works, but writes are disabled.",
+        fix: "If the cathedral needs to write, set REMEMBRANCE_FIELD_TOKEN to the field-server's FIELD_TOKEN, then redeploy.",
+      });
+
+  const ok = checks.filter((c) => c.level === "critical").every((c) => c.ok);
+  const failed = checks.filter((c) => !c.ok && c.level === "critical").map((c) => c.name);
+  const summary = ok ? "Field connected and wired." : `Not connected — ${failed.join(", ")}. See the fix on each red row.`;
+
+  return NextResponse.json(
+    {
+      ok,
+      summary,
+      reachable,
+      effectiveEndpoint: endpoint || "(none)",
+      env: {
+        REMEMBRANCE_FIELD_URL: rawUrl || "(not set)",
+        REMEMBRANCE_FIELD_TOKEN: token ? `set (${token.length} chars)` : "(not set — needed for writes only)",
+      },
+      checks,
+      state: state ? { coherence: state.coherence, updateCount: state.updateCount } : null,
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
+}

--- a/digital-cathedral/app/lib/valor/remembrance-bridge.ts
+++ b/digital-cathedral/app/lib/valor/remembrance-bridge.ts
@@ -37,6 +37,12 @@ function fieldUrl(): string {
   return url;
 }
 
+/** The effective MCP endpoint this runtime will call (scheme normalized, /mcp
+ *  appended). Exposed so the field-health probe can show exactly what gets hit. */
+export function fieldEndpoint(): string {
+  return fieldUrl();
+}
+
 function authToken(): string {
   return (process.env.REMEMBRANCE_FIELD_TOKEN || "").trim();
 }

--- a/scripts/field-server.js
+++ b/scripts/field-server.js
@@ -686,6 +686,7 @@ function manifest() {
     mcp: { endpoint: '/mcp', transport: 'streamable-http (JSON-RPC 2.0)', protocolVersion: DEFAULT_PROTOCOL, tools: TOOLS },
     rest: {
       'GET /': 'health + field peek',
+      'GET /health': 'deep readiness self-check (token, durable volume, pattern corpus, field) — each problem carries a plain fix',
       'GET /field': 'read current field state',
       'POST /coherency': '{ a, b } -> { coherency }  (open)',
       'POST /resonance': '{ code, language?, k? } -> { score, bestMatch, topMatches, library }  (open — anti-hallucination signal)',
@@ -698,6 +699,65 @@ function manifest() {
       ? 'public reads; writes (field_contribute / POST /contribute) require Authorization: Bearer <FIELD_TOKEN>'
       : 'open (no FIELD_TOKEN set — anyone can read and write)',
     cors: 'enabled (*)',
+  };
+}
+
+// Deep readiness self-check — the one place that answers "is this field server
+// actually wired?" in plain language. Every failing check carries a `fix` a
+// non-engineer can act on. Best-effort: never throws; an internal error just
+// degrades that single check. GET /health.
+function health() {
+  const checks = [];
+  const add = (name, ok, level, detail, fix) => checks.push(fix ? { name, ok, level, detail, fix } : { name, ok, level, detail });
+
+  // 1) Write auth posture.
+  add('Write token', !!TOKEN, TOKEN ? 'info' : 'warn',
+    TOKEN ? 'FIELD_TOKEN set — reads are open, writes require the bearer.' : 'No FIELD_TOKEN — writes are OPEN to anyone who can reach this URL.',
+    TOKEN ? undefined : 'Set the FIELD_TOKEN env var on the host (Railway → Variables) to require a bearer token for writes.');
+
+  // 2) Durable persistence — is state on a mounted volume, and is it writable?
+  const stateDir = process.env.REMEMBRANCE_STATE_DIR || process.env.ORACLE_ROOT || '';
+  const entropyPath = process.env.ENTROPY_PATH || '';
+  let writable = false, wdetail = '';
+  try {
+    const fs = require('node:fs'); const path = require('node:path');
+    const dir = entropyPath ? path.dirname(entropyPath) : (stateDir || '');
+    if (dir) { fs.mkdirSync(dir, { recursive: true }); fs.accessSync(dir, fs.constants.W_OK); writable = true; wdetail = 'writable at ' + (entropyPath || dir); }
+    else wdetail = 'no persistence path configured';
+  } catch (e) { wdetail = 'NOT writable: ' + ((e && e.message) || e); }
+  if (!stateDir) {
+    add('Durable volume', false, 'warn',
+      'REMEMBRANCE_STATE_DIR is not set — the field and legacies are EPHEMERAL and reset on every restart (' + wdetail + ').',
+      'Mount a persistent volume (e.g. at /data) and set REMEMBRANCE_STATE_DIR=/data so entropy.json and oracle.db survive restarts.');
+  } else {
+    add('Durable volume', writable, writable ? 'info' : 'critical',
+      'REMEMBRANCE_STATE_DIR=' + stateDir + ' — ' + wdetail,
+      writable ? undefined : 'The state directory is not writable. Confirm a volume is mounted there and the process user can write to it.');
+  }
+
+  // 3) Pattern corpus — what resonance and the goggles score against.
+  let lib = null;
+  try { lib = require('../src/scoring/pattern-resonance').libraryStatus(); } catch (_) { /* degrade */ }
+  const libOk = !!(lib && lib.loaded && lib.count > 0);
+  add('Pattern corpus', libOk, libOk ? 'info' : 'warn',
+    libOk ? ('resonance library loaded — ' + lib.count + ' patterns') : ('no pattern corpus — pattern_resonance and goggles will return null' + (lib && lib.error ? ' (' + lib.error + ')' : '')),
+    libOk ? undefined : 'Bundle patterns.json with the server (it is COPYed in Dockerfile.field-server) or seed the SQLite patterns table on the volume.');
+
+  // 4) Field core answering.
+  let field = null;
+  try { field = peekField(); } catch (_) { /* degrade */ }
+  add('Field state', !!field, field ? 'info' : 'critical',
+    field ? ('coherence ' + field.coherence + ', ' + field.updateCount + ' updates, ' + Object.keys(field.sources || {}).length + ' sources') : 'the field core returned nothing.',
+    field ? undefined : 'Check the server logs — the Living Remembrance Engine failed to load.');
+
+  const ok = checks.filter((c) => c.level === 'critical').every((c) => c.ok);
+  return {
+    ok,
+    service: 'remembrance-field',
+    version: '0.2.0',
+    summary: ok ? 'Field server healthy and wired.' : 'Problems: ' + checks.filter((c) => !c.ok && c.level === 'critical').map((c) => c.name).join(', ') + ' — see the fix on each failing check.',
+    checks,
+    field,
   };
 }
 
@@ -803,6 +863,7 @@ const server = http.createServer((req, res) => {
 
   if (req.method === 'GET') {
     if (path === '/mcp') return send(res, 405, { error: 'MCP endpoint — POST JSON-RPC here' });
+    if (path === '/health' || path === '/healthz') return send(res, 200, health());
     if (path === '/.well-known/mcp' || path === '/manifest') return send(res, 200, manifest());
     let field = null; try { field = peekField(); } catch (_e) { /* best-effort */ }
     if (path === '/field') return send(res, 200, { ok: true, field });


### PR DESCRIPTION
…hedral

Stops blind troubleshooting: every field seam now reports, in plain language, whether it is wired and exactly how to fix it when it is not.

- field-server: GET /health — deep self-check returning { ok, summary, checks[] } for write-token posture, durable volume (warns when state is ephemeral), pattern corpus (count, or how to ship it), and the field core answering. Each failing check carries a `fix`. Verified live locally: 200, all checks pass.
- digital-cathedral: GET /api/field/health — same shape and SAME path as the interface, so "open /api/field/health on either app" is the one rule. Reports URL set / scheme present / field answers / write token, each with a fix. This closes the cathedral's blind spot: /api/health only checked DB+memory and /api/coherency-vitals silently dropped the field section when it was down.
- remembrance-bridge: export fieldEndpoint() so the probe shows the exact /mcp URL it calls.


Claude-Session: https://claude.ai/code/session_01XeuEWbZGDznSTjSePTMC6L