### PR TITLE
feat(cathedral): resonance lead search + wire fabricated numbers to r…

### DIFF
--- a/DEPLOY-FIELD.md
+++ b/DEPLOY-FIELD.md
@@ -1,0 +1,81 @@
+# Deploy the Field — the engine behind the interface
+
+This deploys **one thing**: the Remembrance **field-server** (the LRE engine).
+It is the only piece the interface needs to come alive. One deploy → one URL →
+the console, the Valor Legacies database, Claude's recall, every number — all
+light up. Until it's set, the interface honestly shows **zeros**.
+
+> **Why not just the GitHub token?** The GitHub token edits your repos' *code*.
+> This deploys a *running program* the interface can talk to over HTTP. A repo is
+> a blueprint; this is the engine actually running.
+>
+> **Do I need `ORACLE_URL`, `VOID_URL`, …?** No. Those only color the per-service
+> status dots on the console (health probes against separately-deployed services).
+> Leave them blank and those nodes show "down" — everything else works. The
+> **only** variable that matters is `REMEMBRANCE_FIELD_URL`.
+
+The image is `Dockerfile.field-server` (node:22-slim, non-root, healthcheck,
+persists to `/data`). `railway.json` already points at it. The same image runs on
+Railway, Fly, Render, or any container host.
+
+---
+
+## Railway (recommended — ~4 steps)
+
+1. **New Project → Deploy from GitHub repo →** `remembrance-oracle-toolkit`.
+   Railway reads `railway.json` and builds `Dockerfile.field-server` automatically.
+2. **Add a Volume** (service → *Volumes*), mount path **`/data`**.
+   *(The image already sets `REMEMBRANCE_STATE_DIR=/data`, so this is the only
+   persistence step. Skip it and the field resets on every restart.)*
+3. **Variables →** set `FIELD_TOKEN` to a strong secret (this gates writes).
+4. **Deploy.** When it's green, open *Settings → Networking → Generate Domain* and
+   copy the `https://…up.railway.app` URL.
+
+That URL is your field. Verify it:
+
+```bash
+curl https://YOUR-FIELD.up.railway.app/                       # -> 200
+curl -s -X POST https://YOUR-FIELD.up.railway.app/mcp \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"field_read","arguments":{}}}'
+# -> a JSON field state with coherence + updateCount
+```
+
+---
+
+## Wire the interface (the part that flips zeros → live)
+
+Wherever the **interface** is deployed (e.g. Vercel project settings → Environment
+Variables), set:
+
+| Variable | Value |
+|---|---|
+| `REMEMBRANCE_FIELD_URL` | `https://YOUR-FIELD.up.railway.app` (the URL from above) |
+| `REMEMBRANCE_FIELD_TOKEN` | the **same** secret you set as `FIELD_TOKEN` |
+
+Redeploy the interface. The console, database, vitals, and Claude recall now read
+the live field. (`REMEMBRANCE_FIELD_TOKEN` is only needed for *writes* — creating
+records, chat memory; reads work without it.)
+
+---
+
+## Other hosts (same image)
+
+```bash
+# Fly.io
+fly launch --dockerfile Dockerfile.field-server --name your-field
+fly volumes create data --size 1            # then mount at /data
+fly secrets set FIELD_TOKEN=your-secret
+
+# Render — New → Web Service → Docker, dockerfilePath Dockerfile.field-server,
+#   add a Disk mounted at /data, env FIELD_TOKEN=your-secret
+
+# Any VPS with Docker
+docker build -t remembrance-field -f Dockerfile.field-server .
+docker run -d -p 7787:7787 -e FIELD_TOKEN=your-secret \
+  -v /srv/remembrance:/data remembrance-field
+```
+
+**Always mount a volume at `/data`.** Without it the field and the Valor Legacies
+database are ephemeral and reset on restart (the server prints this warning on
+boot). With it, `entropy.json` + `oracle.db` survive across restarts.

--- a/digital-cathedral/app/api/pricing/route.ts
+++ b/digital-cathedral/app/api/pricing/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { getPricingConfig } from "@/app/lib/pricing-config";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Public lead price list — the single source of truth for the pricing tiers the
+ * marketplace shows agents. Reads the admin-adjustable pricing-config so the
+ * displayed tiers always match what the admin set (no more hardcoded numbers in
+ * the page). Returns cents; the client formats. No PII, safe to be public.
+ */
+export async function GET() {
+  const cfg = getPricingConfig();
+  return NextResponse.json(
+    {
+      tiers: cfg.tiers.map((t) => ({ name: t.name, maxBuyers: t.maxBuyers, basePrice: t.basePrice })),
+      maxPrice: cfg.maxPrice,
+      priceFloor: cfg.priceFloor,
+      updatedAt: cfg.updatedAt,
+    },
+    { headers: { "cache-control": "public, s-maxage=60, stale-while-revalidate=300" } },
+  );
+}

--- a/digital-cathedral/app/faq/page.tsx
+++ b/digital-cathedral/app/faq/page.tsx
@@ -67,7 +67,7 @@ const FAQS = [
   },
   {
     q: "How much life insurance does a military family need?",
-    a: "Financial advisors typically recommend 10-12 times your annual income in life insurance coverage. For military families, consider your BAH, base pay, special pay, and benefits that would stop if something happened. SGLI covers up to $400,000, but many families need additional coverage — especially those with mortgages, children, or a non-working spouse.",
+    a: "Financial advisors typically recommend 10-12 times your annual income in life insurance coverage. For military families, consider your BAH, base pay, special pay, and benefits that would stop if something happened. SGLI covers up to $500,000, but many families need additional coverage — especially those with mortgages, children, or a non-working spouse.",
   },
   {
     q: "Does Valor Legacies serve all 50 states?",

--- a/digital-cathedral/app/lib/valor/resonance-search.ts
+++ b/digital-cathedral/app/lib/valor/resonance-search.ts
@@ -1,0 +1,60 @@
+/**
+ * Lexical pattern-resonance for the marketplace search.
+ *
+ * The same signal the field's pattern_resonance uses — vocabulary overlap —
+ * applied to lead records instead of code. As an agent types, each lead is
+ * scored by how strongly its terms resonate with the query, and a partial word
+ * still resonates with its completion ("tex" → "texas"): the "guess the word
+ * you're spelling" behaviour, driven by resonance rather than a fixed dictionary.
+ *
+ * Pure and dependency-free, so it runs identically in the browser (live, on every
+ * keystroke) and on the server.
+ */
+
+const TOKEN_RE = /[a-z0-9]+/g;
+
+export function tokenize(s: string): string[] {
+  return String(s || "").toLowerCase().match(TOKEN_RE) || [];
+}
+
+/**
+ * How strongly `text` resonates with the typed `query`, in [0, 1]. Exact token
+ * matches resonate fully; a partial word resonates with the term it is on its
+ * way to spelling (prefix), and a contained fragment resonates weakly. Normalised
+ * by query length, so the score is "what fraction of what I typed resonated".
+ */
+export function resonance(query: string, text: string): number {
+  const q = tokenize(query);
+  if (q.length === 0) return 0;
+  const doc = new Set(tokenize(text));
+  if (doc.size === 0) return 0;
+  let hit = 0;
+  for (const t of q) {
+    if (doc.has(t)) { hit += 1; continue; }
+    let best = 0;
+    for (const d of doc) {
+      if (d.startsWith(t) || t.startsWith(d)) { best = Math.max(best, 0.75); }
+      else if (t.length >= 3 && d.includes(t)) { best = Math.max(best, 0.45); }
+    }
+    hit += best;
+  }
+  return Math.max(0, Math.min(1, hit / q.length));
+}
+
+/**
+ * Suggest the vocabulary terms that resonate most with the last (possibly
+ * partial) word being typed — the type-ahead completions. Skips terms already
+ * present in the query.
+ */
+export function suggestTerms(query: string, vocab: readonly string[], k = 6): string[] {
+  const toks = tokenize(query);
+  const last = toks[toks.length - 1] || "";
+  if (!last) return [];
+  const already = new Set(toks);
+  return vocab
+    .map((term) => ({ term, score: resonance(last, term) }))
+    .filter((x) => x.score > 0 && !already.has(x.term.toLowerCase()))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, k)
+    .map((x) => x.term);
+}

--- a/digital-cathedral/app/portal/marketplace/page.tsx
+++ b/digital-cathedral/app/portal/marketplace/page.tsx
@@ -12,9 +12,10 @@
  *  - Delivery filter management
  */
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { US_STATES } from "../../../packages/shared/src/validate-state";
+import { resonance, suggestTerms } from "../../lib/valor/resonance-search";
 
 const COVERAGE_LABELS: Record<string, string> = {
   "mortgage-protection": "Term Life",
@@ -89,6 +90,9 @@ interface Filters {
   distributionMode: string;
 }
 
+interface PricingTier { name: string; maxBuyers: number; basePrice: number; }
+interface PricingData { tiers: PricingTier[]; maxPrice: number; priceFloor: number; }
+
 type Tab = "leads" | "purchases" | "billing" | "filters";
 
 export default function AgentPortal() {
@@ -110,6 +114,9 @@ export default function AgentPortal() {
   // Lead filters
   const [filterState, setFilterState] = useState("");
   const [filterCoverage, setFilterCoverage] = useState("");
+  // Resonance search query + admin-driven pricing.
+  const [query, setQuery] = useState("");
+  const [pricing, setPricing] = useState<PricingData | null>(null);
 
   const fetchProfile = useCallback(async () => {
     try {
@@ -133,7 +140,8 @@ export default function AgentPortal() {
     const params = new URLSearchParams();
     if (filterState) params.set("state", filterState);
     if (filterCoverage) params.set("coverage", filterCoverage);
-    params.set("limit", "25");
+    // Pull a healthy pool so the resonance search has something to rank over.
+    params.set("limit", "100");
 
     const res = await fetch(`/api/client/leads?${params}`);
     if (res.ok) {
@@ -211,6 +219,50 @@ export default function AgentPortal() {
       window.history.replaceState({}, "", "/portal/marketplace");
     }
   }, []);
+
+  // Pricing tiers from the admin-adjustable config — no hardcoded numbers.
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/pricing")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (alive && d?.tiers) setPricing(d as PricingData); })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, []);
+
+  // ── Resonance search over the loaded leads ──
+  // Each lead is scored by how strongly its terms (state, coverage, veteran
+  // status, tier) resonate with what the agent typed — the same vocabulary
+  // resonance the field uses — re-ranked live, partial words resonating toward
+  // their completion ("tex" → "texas").
+  const stateName = useCallback(
+    (code: string) => US_STATES.find((s) => s.code === code)?.name || code,
+    [],
+  );
+  const leadText = useCallback(
+    (l: AvailableLead) =>
+      [stateName(l.state), l.state, COVERAGE_LABELS[l.coverageInterest] || l.coverageInterest, l.coverageInterest, l.veteranStatus, l.tier]
+        .join(" ")
+        .replace(/-/g, " "),
+    [stateName],
+  );
+  const ranked = useMemo(() => {
+    if (!query.trim()) return leads;
+    return leads
+      .map((l) => ({ l, r: resonance(query, leadText(l)) }))
+      .filter((x) => x.r > 0)
+      .sort((a, b) => b.r - a.r || b.l.score - a.l.score)
+      .map((x) => x.l);
+  }, [leads, query, leadText]);
+  const vocab = useMemo(() => {
+    const set = new Set<string>();
+    for (const l of leads) {
+      set.add(stateName(l.state));
+      set.add(COVERAGE_LABELS[l.coverageInterest] || l.coverageInterest);
+    }
+    return [...set];
+  }, [leads, stateName]);
+  const suggestions = useMemo(() => suggestTerms(query, vocab), [query, vocab]);
 
   const handlePurchase = async (leadId: string, tierIndex: number) => {
     setMessage("");
@@ -341,6 +393,36 @@ export default function AgentPortal() {
       {/* ─── Available Leads Tab ─── */}
       {tab === "leads" && (
         <>
+          {/* Resonance search — type anything; leads re-rank by how strongly they resonate */}
+          <div className="cathedral-surface p-4 mb-4">
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search leads by resonance — e.g. “texas veteran final expense”"
+              aria-label="Search leads by resonance"
+              className="w-full bg-[var(--bg-surface)] text-[var(--text-primary)] border border-indigo-cathedral/10 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-indigo-cathedral/25"
+            />
+            {suggestions.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mt-2">
+                {suggestions.map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => setQuery((q) => { const parts = q.split(/\s+/); parts[parts.length - 1] = s; return parts.join(" ") + " "; })}
+                    className="px-2 py-0.5 rounded text-xs text-teal-cathedral border border-teal-cathedral/20 hover:bg-teal-cathedral/10"
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            )}
+            {query.trim() && (
+              <p className="text-[11px] text-[var(--text-muted)] mt-2">
+                {ranked.length} lead{ranked.length === 1 ? "" : "s"} resonate with “{query.trim()}”
+              </p>
+            )}
+          </div>
+
           <div className="cathedral-surface p-4 mb-4">
             <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
               <select value={filterState} onChange={(e) => setFilterState(e.target.value)}
@@ -353,7 +435,7 @@ export default function AgentPortal() {
                 <option value="">All Coverage</option>
                 {Object.entries(COVERAGE_LABELS).map(([val, label]) => <option key={val} value={val}>{label}</option>)}
               </select>
-              <button onClick={() => { setFilterState(""); setFilterCoverage(""); }} className="text-sm text-teal-cathedral underline py-2">Clear</button>
+              <button onClick={() => { setFilterState(""); setFilterCoverage(""); setQuery(""); }} className="text-sm text-teal-cathedral underline py-2">Clear</button>
             </div>
           </div>
 
@@ -372,10 +454,10 @@ export default function AgentPortal() {
               <tbody>
                 {loading ? (
                   <tr><td colSpan={6} className="px-4 py-8 text-center text-[var(--text-muted)]">Loading leads...</td></tr>
-                ) : leads.length === 0 ? (
-                  <tr><td colSpan={6} className="px-4 py-8 text-center text-[var(--text-muted)]">No leads available.</td></tr>
+                ) : ranked.length === 0 ? (
+                  <tr><td colSpan={6} className="px-4 py-8 text-center text-[var(--text-muted)]">{query.trim() ? `No leads resonate with “${query.trim()}”.` : "No leads available."}</td></tr>
                 ) : (
-                  leads.map((lead) => (
+                  ranked.map((lead) => (
                     <tr key={lead.leadId} className="border-b border-indigo-cathedral/5 hover:bg-[var(--bg-surface)]/50 transition-colors">
                       <td className="px-4 py-3">
                         <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium border ${TIER_STYLES[lead.tier] || ""}`}>
@@ -534,18 +616,29 @@ export default function AgentPortal() {
           <div className="cathedral-surface p-6">
             <h3 className="text-lg font-light text-[var(--text-primary)] mb-4">Lead Pricing Tiers</h3>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-              {[
-                { name: "Exclusive", buyers: "1 buyer", price: 12000, cardClass: "metallic-gold-card", labelClass: "metallic-gold" },
-                { name: "Semi-Exclusive", buyers: "2 buyers", price: 10000, cardClass: "metallic-silver-card", labelClass: "metallic-silver" },
-                { name: "Warm Shared", buyers: "3–4 buyers", price: 8000, cardClass: "metallic-bronze-card", labelClass: "metallic-bronze" },
-                { name: "Cool Shared", buyers: "5–6 buyers", price: 6000, cardClass: "metallic-sky-card", labelClass: "metallic-sky" },
-              ].map((t) => (
-                <div key={t.name} className={`rounded-lg p-4 text-center ${t.cardClass}`}>
-                  <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${t.labelClass}`}>{t.name}</p>
-                  <p className={`text-2xl font-bold ${t.labelClass}`}>{formatCents(t.price)}</p>
-                  <p className="text-xs text-[var(--text-muted)] mt-1">{t.buyers}</p>
-                </div>
-              ))}
+              {(() => {
+                const styles = [
+                  { cardClass: "metallic-gold-card", labelClass: "metallic-gold" },
+                  { cardClass: "metallic-silver-card", labelClass: "metallic-silver" },
+                  { cardClass: "metallic-bronze-card", labelClass: "metallic-bronze" },
+                  { cardClass: "metallic-sky-card", labelClass: "metallic-sky" },
+                ];
+                const tiers = pricing?.tiers ?? [];
+                const buyersLabel = (n: number) => (n <= 1 ? "1 buyer" : `up to ${n} buyers`);
+                if (tiers.length === 0) {
+                  return <p className="col-span-2 md:col-span-4 text-sm text-[var(--text-muted)] text-center py-2">Loading pricing…</p>;
+                }
+                return tiers.map((t, i) => {
+                  const s = styles[i % styles.length];
+                  return (
+                    <div key={t.name} className={`rounded-lg p-4 text-center ${s.cardClass}`}>
+                      <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${s.labelClass}`}>{t.name}</p>
+                      <p className={`text-2xl font-bold ${s.labelClass}`}>{formatCents(t.basePrice)}</p>
+                      <p className="text-xs text-[var(--text-muted)] mt-1">{buyersLabel(t.maxBuyers)}</p>
+                    </div>
+                  );
+                });
+              })()}
             </div>
           </div>
 
@@ -566,7 +659,7 @@ export default function AgentPortal() {
                 </div>
                 <div className="grid grid-cols-3 gap-3 text-center">
                   <div>
-                    <p className="text-xl font-bold text-teal-cathedral">$120</p>
+                    <p className="text-xl font-bold text-teal-cathedral">{pricing ? formatCents(pricing.maxPrice) : "$120"}</p>
                     <p className="text-[10px] text-[var(--text-muted)]">Cost per Lead</p>
                   </div>
                   <div>

--- a/digital-cathedral/app/protect/components/trust-signals.tsx
+++ b/digital-cathedral/app/protect/components/trust-signals.tsx
@@ -17,28 +17,28 @@
 import { useState, useEffect, useCallback } from "react";
 
 // --- Live Activity Counter ---
+// Real verified-request volume from the field's ledger — admissions that passed
+// the covenant gate in the trailing 24h, via /api/coherency-vitals. Honest by
+// construction: when there is no real activity yet it renders nothing, rather
+// than a fabricated number.
 function LiveActivityCounter() {
-  const [count, setCount] = useState(0);
+  const [count, setCount] = useState<number | null>(null);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    // Generate a plausible daily count based on the day of week
-    // Higher on weekdays, lower on weekends
-    const day = new Date().getDay();
-    const isWeekend = day === 0 || day === 6;
-    const base = isWeekend ? 12 : 27;
-    const variance = Math.floor(Math.random() * 15);
-    const hours = new Date().getHours();
-    // Scale by time of day — more activity during business hours
-    const timeScale = hours >= 8 && hours <= 20 ? 1 : 0.4;
-    setCount(Math.floor((base + variance) * timeScale));
+    let alive = true;
+    fetch("/api/coherency-vitals")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (alive) setCount(typeof d?.admitted24h === "number" ? d.admitted24h : 0); })
+      .catch(() => { if (alive) setCount(0); });
 
     // Fade in after mount
     const timer = setTimeout(() => setVisible(true), 300);
-    return () => clearTimeout(timer);
+    return () => { alive = false; clearTimeout(timer); };
   }, []);
 
-  if (count === 0) return null;
+  // Hide until there is a real, non-zero count — never invent social proof.
+  if (count === null || count <= 0) return null;
 
   return (
     <div
@@ -49,7 +49,7 @@ function LiveActivityCounter() {
         <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-teal-cathedral"></span>
       </span>
       <p className="text-sm text-[var(--text-muted)]">
-        <span className="font-medium text-[var(--text-primary)]">{count} people</span> requested quotes today
+        <span className="font-medium text-[var(--text-primary)]">{count} {count === 1 ? "person" : "people"}</span> requested a quote in the last 24 hours
       </p>
     </div>
   );


### PR DESCRIPTION
…eal data

Two requested features for the digital cathedral.

1) Marketplace resonance search (agent portal -> Leads tab)
   - New resonance-search util: lexical pattern-resonance (the same vocabulary- overlap signal the field's pattern_resonance uses) scoring each lead's terms (state, coverage, veteran status, tier) against what the agent types. Partial words resonate toward their completion ("tex" -> "texas") — type-ahead by resonance, not a fixed dictionary. Pure/dependency-free; runs live per keystroke in the browser.
   - Search box + resonance-ranked results + suggestion chips. Lead pool fetch bumped to 100 so the ranking has real depth. Verified: "tex veteran" ranks a Texas+veteran lead 0.875 over a non-matching one at 0.0.

2) Replace fabricated/placeholder numbers with real data (per "real placeholders
   only" — regulatory/config constants left as the facts they are):
   - trust-signals "live activity counter": was Math.random(); now reads real trailing-24h admissions from /api/coherency-vitals, and renders nothing when there is no real activity (no invented social proof).
   - marketplace pricing tiers + ROI "cost per lead": were hardcoded; now read the admin-adjustable pricing-config via a new public /api/pricing endpoint.
   - FAQ SGLI max coverage $400,000 -> $500,000, resolving the conflict with the military-family landing page (current SGLI max is $500k).

Verified: tsc --noEmit clean on the cathedral.


Claude-Session: https://claude.ai/code/session_01XeuEWbZGDznSTjSePTMC6L