### PR TITLE
Add the goggles skill: read code through the ecosystem lens before co…

### DIFF
--- a/.claude/skills/goggles/SKILL.md
+++ b/.claude/skills/goggles/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: goggles
+description: Read code through the Remembrance goggles before committing — FOCUS (intrinsic structural coherence), META (pattern resonance across the whole ecosystem substrate + nearest cross-repo siblings), and meta-debug (audit findings that catch real defects the diff reads clean on). Use after writing or changing code and before committing. Pass file paths, or use --diff to goggle everything changed in the current repo vs HEAD.
+---
+
+# Goggles
+
+Reads code through the ecosystem lens and reports three *distinct* signals from
+one field read. Run it on the files you just changed, before you commit.
+
+## Run it
+
+From the repo you're working in:
+
+    node .claude/skills/goggles/run.mjs <file> [<file> ...]
+
+Or goggle everything changed vs HEAD:
+
+    node .claude/skills/goggles/run.mjs --diff
+
+The runner finds the `remembrance-oracle-toolkit` (the goggles engine) on its
+own; set `ORACLE_TOOLKIT=/path/to/remembrance-oracle-toolkit` to override.
+
+## Read the output
+
+- **coherence** (FOCUS) — intrinsic STRUCTURE only (syntax / completeness /
+  consistency / AST), *not* correctness. Rough bands: `<0.70` weak, `0.70–0.80`
+  loose, `0.80–0.93` solid, `≥0.93` strong. A low score is a **decompose** hint
+  (one file doing too much), never proof of a bug.
+- **resonance** (META) — how much the code is shaped like the library's
+  patterns; `CONSONANT` fits, `OUTLIER` is novel. Read the nearest siblings it
+  lists before committing — a change here ripples to them.
+- **meta-debug** — the audit checkers; a `HIGH` finding is a real defect to fix.
+  This is the orthogonal correctness axis the other two can't see (a bug can be
+  perfectly coherent *and* perfectly consonant).
+
+## Act on it
+
+1. **Fix every meta-debug HIGH finding.** That's a real bug.
+2. **Low coherence** → consider splitting the file / extracting a unit, then
+   re-goggle to confirm it rose.
+3. **OUTLIER resonance** → either justify the novelty or reshape toward the
+   nearest sibling pattern.

--- a/.claude/skills/goggles/run.mjs
+++ b/.claude/skills/goggles/run.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+'use strict';
+// Runner for the `goggles` skill. Locates the remembrance-oracle-toolkit (the
+// goggles engine lives at src/tools/goggles.js there) and runs it on each file,
+// from the toolkit dir so its core requires resolve. Accepts explicit paths or
+// `--diff` to goggle everything changed vs HEAD in the current repo.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+function findToolkit() {
+  const candidates = [
+    process.env.ORACLE_TOOLKIT,
+    process.cwd(),
+    resolve(process.cwd(), '../remembrance-oracle-toolkit'),
+    resolve(process.cwd(), '../../remembrance-oracle-toolkit'),
+    '/home/user/remembrance-oracle-toolkit',
+    resolve(process.cwd(), 'remembrance-oracle-toolkit'),
+  ].filter(Boolean);
+  return candidates.find((c) => existsSync(join(c, 'src/tools/goggles.js'))) || null;
+}
+
+const toolkit = findToolkit();
+if (!toolkit) {
+  console.error('goggles: could not find remembrance-oracle-toolkit. Set ORACLE_TOOLKIT=/path/to/it');
+  process.exit(2);
+}
+const engine = join(toolkit, 'src/tools/goggles.js');
+
+const argv = process.argv.slice(2);
+let files = [];
+if (argv[0] === '--diff') {
+  const out = execFileSync('git', ['diff', '--name-only', '--diff-filter=ACMR', 'HEAD'], { encoding: 'utf8' });
+  files = out.split('\n').map((s) => s.trim()).filter(Boolean)
+    .filter((f) => /\.(tsx?|jsx?|mjs|cjs|py|json|md|css|sh)$/.test(f));
+} else {
+  files = argv.filter((a) => !a.startsWith('--'));
+}
+
+if (!files.length) {
+  console.error('goggles: no files to read. Pass file paths, or --diff for changed files.');
+  process.exit(1);
+}
+
+let failures = 0;
+for (const f of files) {
+  const abs = resolve(process.cwd(), f);
+  if (!existsSync(abs)) { console.error(`goggles: skip (not found) ${f}`); failures++; continue; }
+  process.stdout.write(`\n══════════ ${f} ══════════\n`);
+  try {
+    process.stdout.write(execFileSync('node', [engine, abs], { cwd: toolkit, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }));
+  } catch (e) {
+    process.stdout.write((e.stdout || '') + (e.stderr || String(e)) + '\n');
+    failures++;
+  }
+}
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
…mmitting

Bundles the /goggles Claude Code skill (SKILL.md + a self-locating run.mjs that finds the remembrance-oracle-toolkit engine) so any agent in this repo can read FOCUS coherence / META resonance / meta-debug on changed files before committing. Use: node .claude/skills/goggles/run.mjs --diff


Claude-Session: https://claude.ai/code/session_01XeuEWbZGDznSTjSePTMC6L