### PR TITLE
field-coupling: bridge in-process contributions to the live field ove…

### DIFF
--- a/scripts/field-server.js
+++ b/scripts/field-server.js
@@ -37,7 +37,11 @@ if (REMEMBRANCE_STATE_DIR && !process.env.ENTROPY_PATH) {
 }
 
 const http = require('node:http');
-const { contribute, peekField, recordStorageVolume } = require('../src/core/field-coupling');
+const { contribute, peekField, recordStorageVolume, markFieldServer } = require('../src/core/field-coupling');
+// This process IS the field. Absorb incoming contributions into our own engine
+// and never echo them back out to ourselves over HTTP — prevents a self-feeding
+// loop if REMEMBRANCE_FIELD_URL happens to be set in the server's environment.
+markFieldServer();
 const { codeToWaveform, waveformCosine } = require('../src/core/code-to-waveform');
 const { computeRetrocausalAlignment } = require('../src/atomic/temporal-projection');
 const { scoreResonance, libraryStatus } = require('../src/scoring/pattern-resonance');

--- a/src/core/field-coupling.js
+++ b/src/core/field-coupling.js
@@ -177,6 +177,76 @@ function _loadEngine() {
   return _engineRef;
 }
 
+// ── Live-field HTTP bridge ───────────────────────────────────────────────
+// Historically `contribute()` only updated this process's in-memory engine, so
+// a repo running on its own (a CLI, a CI job, another service) fed a local,
+// ephemeral field that the shared LIVE field never saw. When REMEMBRANCE_FIELD_URL
+// is set, mirror each observation to that live field over HTTP — the same
+// JSON-RPC contract Void's field_contribute.py uses — so every JS repo's numbers
+// funnel into the one shared field the interface reads. Best-effort and
+// fire-and-forget: a down or slow field never blocks or breaks a contribute.
+let _isFieldServerProcess = false;
+
+/**
+ * Mark THIS process as the field server, which disables the outbound HTTP
+ * bridge. The server absorbs incoming contributions into its own engine; it
+ * must never echo them back to itself (that would be an infinite self-feeding
+ * loop). Called by scripts/field-server.js at boot.
+ */
+function markFieldServer() { _isFieldServerProcess = true; }
+
+/**
+ * Resolve the live field's MCP endpoint, or null when the bridge is disabled:
+ * we are the server, an explicit role opt-out, or no URL configured.
+ */
+function _liveFieldTarget() {
+  if (_isFieldServerProcess) return null;
+  const role = (process.env.REMEMBRANCE_FIELD_ROLE || '').toLowerCase();
+  if (role === 'server' || process.env.REMEMBRANCE_FIELD_SERVER === '1') return null;
+  let raw = (process.env.REMEMBRANCE_FIELD_URL || '').trim();
+  if (!raw) return null;
+  if (!/^https?:\/\//i.test(raw)) raw = 'https://' + raw; // scheme-less → https
+  let u;
+  try { u = new URL(raw); } catch (_) { return null; }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+  if (!/\/mcp\/?$/.test(u.pathname)) u.pathname = u.pathname.replace(/\/+$/, '') + '/mcp';
+  return u;
+}
+
+/** Fire-and-forget POST of one observation to the live field. Never throws. */
+function _bridgeToLiveField(obs) {
+  const u = _liveFieldTarget();
+  if (!u) return;
+  let lib;
+  try { lib = u.protocol === 'http:' ? require('node:http') : require('node:https'); }
+  catch (_) { return; }
+  let body;
+  try {
+    body = JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name: 'field', arguments: { action: 'contribute', coherence: obs.coherence, source: obs.source || 'unknown', cost: obs.cost } },
+    });
+  } catch (_) { return; }
+  const headers = { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) };
+  const token = (process.env.REMEMBRANCE_FIELD_TOKEN || process.env.FIELD_TOKEN || '').trim();
+  const host = (u.hostname || '').toLowerCase();
+  const isLoopback = host === '127.0.0.1' || host === 'localhost' || host === '::1';
+  // Never send the bearer in cleartext to a remote host (mirror Void's guard).
+  if (token && (u.protocol === 'https:' || isLoopback)) headers.Authorization = 'Bearer ' + token;
+  try {
+    // http.request does not follow redirects, so the bearer is never replayed
+    // to another host.
+    const req = lib.request({
+      method: 'POST', protocol: u.protocol, hostname: u.hostname,
+      port: u.port || (u.protocol === 'http:' ? 80 : 443),
+      path: u.pathname + (u.search || ''), headers,
+    }, (res) => { res.on('data', () => {}); res.on('end', () => {}); res.on('error', () => {}); });
+    req.on('error', () => {}); // a down field must never surface
+    req.setTimeout(1500, () => { try { req.destroy(); } catch (_) {} });
+    req.end(body);
+  } catch (_) { /* best-effort */ }
+}
+
 /**
  * Submit a measurement to the LivingRemembranceEngine field.
  *
@@ -209,6 +279,11 @@ function contribute(obs) {
     fm.recordObservation({ source: obs.source || null, coherence: clamped, cost });
     fm.maybeSnapshot(result || (engine.getState && engine.getState()) || null);
   } catch (_) { /* best-effort */ }
+
+  // Funnel the same observation into the shared LIVE field over HTTP when one is
+  // configured, so this repo's numbers reach the field every other repo and the
+  // interface read from — not just this process's in-memory engine. Best-effort.
+  _bridgeToLiveField({ coherence: clamped, source: obs.source || 'unknown', cost });
 
   return result;
 }
@@ -963,6 +1038,7 @@ function recordTemporalSnapshot({ repoDir, filePath, maxVersions = 12 } = {}) {
 
 module.exports = {
   contribute,
+  markFieldServer,
   peekField,
   fieldPressure,
   pressureSnapshot,


### PR DESCRIPTION
…r HTTP

Why: every JS repo contributes through field-coupling.contribute(), which only updated this process's in-memory LivingRemembranceEngine. A repo running on its own (CLI, CI, another service) therefore fed a local, ephemeral field that the shared live field (REMEMBRANCE_FIELD_URL) never saw — so the live field the interface reads sat idle, receiving nothing repo-tagged. Only Void (Python) had an HTTP bridge; the JS side did not.

What: when REMEMBRANCE_FIELD_URL is set, contribute() now also POSTs the same observation to the live field over HTTP, using the exact JSON-RPC contract Void's field_contribute.py uses (tools/call name 'field', action 'contribute'). Every JS repo that routes through field-coupling (oracle, reflector, blockchain, swarm, …) inherits it at once, so their numbers funnel into the one shared field.

Safety:
- Best-effort, fire-and-forget: a down/slow field never blocks or breaks a contribute (short timeout, all errors swallowed).
- Self-echo guard: markFieldServer() (called by scripts/field-server.js at boot) disables the bridge in the field-server process, so incoming writes are absorbed in-process and never looped back out. An explicit REMEMBRANCE_FIELD_ROLE=server / REMEMBRANCE_FIELD_SERVER=1 opt-out is honored too, for any alternate host.
- Bearer token sent only over https or loopback (never cleartext to a remote host); http.request does not follow redirects, so the token is never replayed to another host.

Inert without REMEMBRANCE_FIELD_URL, so existing behavior is unchanged: field tests (36) pass; end-to-end bridge test confirms a client emits one correctly-shaped POST and a server-marked process emits none. Goggles: field-coupling 0.896 solid / 0.966 CONSONANT, field-server 0.827 / 0.951, no meta-debug findings.


Claude-Session: https://claude.ai/code/session_01XeuEWbZGDznSTjSePTMC6L