### PR TITLE
cathedral: All Leads page + admin-managed lead-notification recipients

### DIFF
--- a/digital-cathedral/app/admin/leads/page.tsx
+++ b/digital-cathedral/app/admin/leads/page.tsx
@@ -1,14 +1,221 @@
-import { redirect } from "next/navigation";
+"use client";
 
 /**
- * /admin/leads — preserved as a redirect to /admin so existing bookmarks
- * still land on the dashboard (which is where the actual lead list lives).
+ * /admin/leads — the all-leads list.
  *
- * The seed-data utility that used to live at this path was renamed to
- * /admin/seed because its actual purpose is seeding test data, not viewing
- * production leads. Anyone who hits /admin/leads expecting a leads list
- * now lands on the dashboard that has the real list + filters.
+ * A focused, always-accessible view of every submitted lead: search by
+ * name/email, filter by submission source, paginate, and export to CSV. Reads
+ * the same /api/admin/leads endpoint the dashboard uses (only admitted leads
+ * are stored; bot/fraud submissions are rejected at the gate and never persist).
  */
-export default function AdminLeadsRedirect(): never {
-  redirect("/admin");
+
+import * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface LeadRow {
+  leadId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  state: string;
+  coverageInterest: string;
+  veteranStatus: string;
+  createdAt: string;
+  score: number;
+  tier: string;
+  coherency?: number;
+  coherencyTier?: string;
+  archetype?: string;
+}
+
+const LIMIT = 50;
+const SOURCES = [
+  { value: "", label: "All sources" },
+  { value: "human", label: "Human" },
+  { value: "agent", label: "Agent" },
+  { value: "lattice", label: "Lattice" },
+] as const;
+
+export default function AdminLeadsPage() {
+  const [leads, setLeads] = useState<LeadRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [search, setSearch] = useState("");
+  const [source, setSource] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Debounce the search box so we don't fire a request per keystroke.
+  const debounced = useDebouncedValue(search, 350);
+
+  const fetchLeads = useCallback(async () => {
+    setLoading(true);
+    setErrorMsg(null);
+    const params = new URLSearchParams();
+    if (debounced) params.set("search", debounced);
+    if (source) params.set("source", source);
+    params.set("limit", String(LIMIT));
+    params.set("offset", String(page * LIMIT));
+    try {
+      const res = await fetch(`/api/admin/leads?${params}`, { cache: "no-store" });
+      if (res.status === 401) {
+        window.location.href = "/admin/login";
+        return;
+      }
+      if (!res.ok) {
+        setErrorMsg("server returned " + res.status);
+        return;
+      }
+      const data = await res.json();
+      setLeads(data.leads ?? []);
+      setTotal(data.total ?? 0);
+    } catch (err) {
+      setErrorMsg("network error: " + (err instanceof Error ? err.message : "unknown"));
+    } finally {
+      setLoading(false);
+    }
+  }, [debounced, source, page]);
+
+  useEffect(() => {
+    fetchLeads();
+  }, [fetchLeads]);
+
+  // Reset to the first page whenever the filters change.
+  useEffect(() => {
+    setPage(0);
+  }, [debounced, source]);
+
+  const exportHref = source
+    ? `/api/admin/export?source=${encodeURIComponent(source)}`
+    : "/api/admin/export";
+
+  const from = total === 0 ? 0 : page * LIMIT + 1;
+  const to = Math.min((page + 1) * LIMIT, total);
+
+  return (
+    <main className="min-h-screen text-[var(--text-primary)] px-6 py-8 max-w-6xl mx-auto">
+      <header className="flex items-baseline justify-between flex-wrap gap-3 mb-4">
+        <h1 className="text-xl font-light text-teal-cathedral">
+          All Leads {total > 0 && <span className="text-[var(--text-muted)] text-sm">· {total.toLocaleString()}</span>}
+        </h1>
+        <div className="flex items-baseline gap-4 text-xs">
+          <a href="/admin" className="text-teal-cathedral/80 hover:text-teal-cathedral">← dashboard</a>
+          <a href={exportHref} className="text-teal-cathedral/80 hover:text-teal-cathedral">export CSV</a>
+        </div>
+      </header>
+
+      {/* Controls */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search name or email…"
+          className="flex-1 min-w-[200px] bg-black/20 border border-teal-cathedral/20 rounded px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-teal-cathedral outline-none"
+        />
+        <select
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          className="bg-black/20 border border-teal-cathedral/20 rounded px-3 py-2 text-sm text-[var(--text-primary)] focus:border-teal-cathedral outline-none"
+        >
+          {SOURCES.map((s) => (
+            <option key={s.value} value={s.value} className="bg-[#0e1525]">
+              {s.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {errorMsg && (
+        <div className="mb-4 px-3 py-2 rounded text-xs border border-rose-500/30 bg-rose-950/30 text-rose-200">
+          {errorMsg}
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="overflow-x-auto border border-teal-cathedral/10 rounded-lg">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-left text-[var(--text-muted)] border-b border-teal-cathedral/10">
+              <th className="px-3 py-2 font-normal">Name</th>
+              <th className="px-3 py-2 font-normal">Email</th>
+              <th className="px-3 py-2 font-normal">Phone</th>
+              <th className="px-3 py-2 font-normal">State</th>
+              <th className="px-3 py-2 font-normal">Coverage</th>
+              <th className="px-3 py-2 font-normal">Veteran</th>
+              <th className="px-3 py-2 font-normal">Tier</th>
+              <th className="px-3 py-2 font-normal">Archetype</th>
+              <th className="px-3 py-2 font-normal">Submitted</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && leads.length === 0 ? (
+              <tr><td colSpan={9} className="px-3 py-6 text-center text-[var(--text-muted)]">Loading…</td></tr>
+            ) : leads.length === 0 ? (
+              <tr><td colSpan={9} className="px-3 py-6 text-center text-[var(--text-muted)]">No leads found.</td></tr>
+            ) : (
+              leads.map((l) => (
+                <tr key={l.leadId} className="border-b border-teal-cathedral/5 hover:bg-black/20">
+                  <td className="px-3 py-2 text-[var(--text-primary)] whitespace-nowrap">{l.firstName} {l.lastName}</td>
+                  <td className="px-3 py-2 text-[var(--text-muted)]">{l.email}</td>
+                  <td className="px-3 py-2 text-[var(--text-muted)] whitespace-nowrap">{l.phone}</td>
+                  <td className="px-3 py-2">{l.state}</td>
+                  <td className="px-3 py-2 text-[var(--text-muted)]">{l.coverageInterest}</td>
+                  <td className="px-3 py-2 text-[var(--text-muted)]">{l.veteranStatus}</td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    <span className="text-teal-cathedral/80">{l.tier}</span>
+                    {typeof l.score === "number" && <span className="text-[var(--text-muted)]"> · {l.score}</span>}
+                  </td>
+                  <td className="px-3 py-2 text-[var(--text-muted)]">{l.archetype ?? "—"}</td>
+                  <td className="px-3 py-2 text-[var(--text-muted)] whitespace-nowrap">
+                    {l.createdAt ? new Date(l.createdAt).toLocaleDateString() : "—"}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {total > LIMIT && (
+        <nav className="flex items-center justify-between mt-4 text-xs" aria-label="Leads pagination">
+          <span className="text-[var(--text-muted)]">
+            Showing {from}–{to} of {total.toLocaleString()}
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-3 py-1.5 rounded border border-teal-cathedral/20 text-teal-cathedral/80 hover:border-teal-cathedral/40 disabled:opacity-40"
+            >
+              ← prev
+            </button>
+            <button
+              onClick={() => setPage((p) => p + 1)}
+              disabled={to >= total}
+              className="px-3 py-1.5 rounded border border-teal-cathedral/20 text-teal-cathedral/80 hover:border-teal-cathedral/40 disabled:opacity-40"
+            >
+              next →
+            </button>
+          </div>
+        </nav>
+      )}
+    </main>
+  );
+}
+
+/** Local debounce so a value only updates after it stops changing for `ms`. */
+function useDebouncedValue<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setDebounced(value), ms);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [value, ms]);
+  return debounced;
 }

--- a/digital-cathedral/app/admin/notifications/page.tsx
+++ b/digital-cathedral/app/admin/notifications/page.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+/**
+ * /admin/notifications — who gets emailed when a new lead is submitted.
+ *
+ * Manages the durable recipient list (stored server-side via the site-content
+ * KV store). Any address here is emailed on every new lead, alongside the
+ * legacy ADMIN_EMAIL env var (shown read-only). Includes a "send test" so the
+ * operator can confirm delivery (and whether SMTP is wired).
+ */
+
+import * as React from "react";
+import { useCallback, useEffect, useState } from "react";
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}
+
+export default function NotificationsPage() {
+  const [recipients, setRecipients] = useState<string[]>([]);
+  const [envEmails, setEnvEmails] = useState<string[]>([]);
+  const [smtpConfigured, setSmtpConfigured] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [draft, setDraft] = useState("");
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [flash, setFlash] = useState<{ ok: boolean; message: string } | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/notifications", { cache: "no-store" });
+      if (res.status === 401) {
+        window.location.href = "/admin/login";
+        return;
+      }
+      if (res.ok) {
+        const data = await res.json();
+        setRecipients(data.recipients ?? []);
+        setEnvEmails(data.envAdminEmails ?? []);
+        setSmtpConfigured(Boolean(data.smtpConfigured));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const addDraft = useCallback(() => {
+    const email = draft.trim().toLowerCase();
+    if (!isValidEmail(email)) {
+      setFlash({ ok: false, message: `"${draft}" is not a valid email.` });
+      return;
+    }
+    if (recipients.includes(email)) {
+      setFlash({ ok: false, message: `${email} is already on the list.` });
+      setDraft("");
+      return;
+    }
+    setRecipients((r) => [...r, email]);
+    setDraft("");
+    setDirty(true);
+    setFlash(null);
+  }, [draft, recipients]);
+
+  const remove = useCallback((email: string) => {
+    setRecipients((r) => r.filter((e) => e !== email));
+    setDirty(true);
+  }, []);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    setFlash(null);
+    try {
+      const res = await fetch("/api/admin/notifications", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ recipients }),
+      });
+      const data = await res.json();
+      if (res.ok && data.success) {
+        setRecipients(data.recipients ?? []);
+        setDirty(false);
+        setFlash({ ok: true, message: "Recipients saved." });
+      } else {
+        setFlash({ ok: false, message: data.message || "Save failed." });
+      }
+    } catch (err) {
+      setFlash({ ok: false, message: "Save error: " + (err instanceof Error ? err.message : "unknown") });
+    } finally {
+      setSaving(false);
+    }
+  }, [recipients]);
+
+  const sendTest = useCallback(async () => {
+    setTesting(true);
+    setFlash(null);
+    try {
+      const res = await fetch("/api/admin/notifications", { method: "POST" });
+      const data = await res.json();
+      if (res.ok && data.success) {
+        setFlash({
+          ok: true,
+          message:
+            `Test sent to ${data.sent} recipient(s)` +
+            (data.failed ? `, ${data.failed} failed` : "") +
+            (data.note ? `. ${data.note}` : "."),
+        });
+      } else {
+        setFlash({ ok: false, message: data.message || "Test failed." });
+      }
+    } catch (err) {
+      setFlash({ ok: false, message: "Test error: " + (err instanceof Error ? err.message : "unknown") });
+    } finally {
+      setTesting(false);
+    }
+  }, []);
+
+  return (
+    <main className="min-h-screen text-[var(--text-primary)] px-6 py-8 max-w-3xl mx-auto">
+      <header className="flex items-baseline justify-between flex-wrap gap-3 mb-2">
+        <h1 className="text-xl font-light text-teal-cathedral">Lead Notifications</h1>
+        <a href="/admin" className="text-xs text-teal-cathedral/80 hover:text-teal-cathedral">
+          ← back to dashboard
+        </a>
+      </header>
+      <p className="text-xs text-[var(--text-muted)] mb-6 max-w-2xl">
+        Everyone listed here is emailed whenever a new lead is submitted. Changes
+        save to the database, so they persist across deploys.
+      </p>
+
+      {!smtpConfigured && (
+        <div className="mb-4 px-3 py-2 rounded text-xs border border-amber-500/30 bg-amber-950/20 text-amber-200">
+          Email sending isn&apos;t configured yet (SMTP_HOST unset), so notifications are
+          logged to the server console instead of delivered. Set SMTP_HOST / SMTP_USER /
+          SMTP_PASS in Vercel to send for real.
+        </div>
+      )}
+
+      {flash && (
+        <div
+          className={
+            "mb-4 px-3 py-2 rounded text-xs " +
+            (flash.ok
+              ? "border border-emerald-500/30 bg-emerald-950/30 text-emerald-200"
+              : "border border-rose-500/30 bg-rose-950/30 text-rose-200")
+          }
+        >
+          {flash.message}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-[var(--text-muted)] text-sm">Loading…</div>
+      ) : (
+        <>
+          {/* Add */}
+          <div className="flex gap-2 mb-4">
+            <input
+              type="email"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addDraft();
+                }
+              }}
+              placeholder="name@example.com"
+              className="flex-1 bg-black/20 border border-teal-cathedral/20 rounded px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-teal-cathedral outline-none"
+            />
+            <button
+              onClick={addDraft}
+              className="px-4 py-2 rounded text-sm bg-teal-cathedral/80 text-white hover:bg-teal-cathedral"
+            >
+              Add
+            </button>
+          </div>
+
+          {/* Managed list */}
+          <div className="border border-teal-cathedral/10 rounded-lg bg-black/10 divide-y divide-teal-cathedral/10 mb-4">
+            {recipients.length === 0 ? (
+              <div className="px-4 py-6 text-sm text-[var(--text-muted)] text-center">
+                No recipients yet. Add an email above to start getting new-lead alerts.
+              </div>
+            ) : (
+              recipients.map((email) => (
+                <div key={email} className="flex items-center justify-between px-4 py-2.5">
+                  <span className="text-sm text-[var(--text-primary)]">{email}</span>
+                  <button
+                    onClick={() => remove(email)}
+                    className="text-xs text-rose-300/80 hover:text-rose-300"
+                    aria-label={`Remove ${email}`}
+                  >
+                    remove
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div className="flex items-center gap-3 mb-8">
+            <button
+              onClick={save}
+              disabled={saving || !dirty}
+              className="px-4 py-2 rounded text-sm bg-indigo-cathedral text-white hover:bg-indigo-cathedral/90 disabled:opacity-50"
+            >
+              {saving ? "saving…" : dirty ? "Save changes" : "Saved"}
+            </button>
+            <button
+              onClick={sendTest}
+              disabled={testing}
+              className="px-4 py-2 rounded text-sm text-teal-cathedral/80 border border-teal-cathedral/20 hover:border-teal-cathedral/40 hover:text-teal-cathedral disabled:opacity-50"
+            >
+              {testing ? "sending…" : "Send test email"}
+            </button>
+          </div>
+
+          {/* Env fallback (read-only) */}
+          {envEmails.length > 0 && (
+            <div>
+              <h2 className="text-[10px] tracking-[0.2em] uppercase text-teal-cathedral mb-2">
+                Always notified · from ADMIN_EMAIL
+              </h2>
+              <div className="border border-teal-cathedral/10 rounded-lg bg-black/10 divide-y divide-teal-cathedral/10">
+                {envEmails.map((email) => (
+                  <div key={email} className="px-4 py-2.5 text-sm text-[var(--text-muted)]">
+                    {email}
+                  </div>
+                ))}
+              </div>
+              <p className="text-[10px] text-[var(--text-muted)] mt-2">
+                Set via the ADMIN_EMAIL environment variable — edit it in Vercel.
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/digital-cathedral/app/admin/page.tsx
+++ b/digital-cathedral/app/admin/page.tsx
@@ -385,6 +385,20 @@ export default function AdminDashboard() {
             Pattern Library
           </button>
           <button
+            onClick={() => router.push("/admin/leads")}
+            className="px-4 py-2 rounded-lg text-sm transition-all bg-teal-cathedral/80 text-white hover:bg-teal-cathedral"
+            title="The full searchable list of every submitted lead"
+          >
+            All Leads
+          </button>
+          <button
+            onClick={() => router.push("/admin/notifications")}
+            className="px-4 py-2 rounded-lg text-sm transition-all bg-teal-cathedral/80 text-white hover:bg-teal-cathedral"
+            title="Choose who gets emailed when a new lead is submitted"
+          >
+            Notifications
+          </button>
+          <button
             onClick={handleExport}
             className="px-4 py-2 rounded-lg text-sm font-medium transition-all text-teal-cathedral/70 border border-teal-cathedral/20 hover:border-teal-cathedral/40 hover:text-teal-cathedral"
           >

--- a/digital-cathedral/app/api/admin/notifications/route.ts
+++ b/digital-cathedral/app/api/admin/notifications/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/app/lib/admin-auth";
+import {
+  getNotificationRecipients,
+  setNotificationRecipients,
+  getLeadNotificationTargets,
+  getEnvAdminEmails,
+} from "@/app/lib/notification-recipients";
+import { sendEmail } from "@/app/lib/email";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Lead-notification recipients admin API.
+ *
+ *   GET  — current managed list + the env ADMIN_EMAIL fallback (read-only).
+ *   PUT  — replace the managed list ({ recipients: string[] }).
+ *   POST — send a test notification to every current target.
+ */
+export async function GET(req: NextRequest) {
+  const authError = verifyAdmin(req);
+  if (authError) return authError;
+
+  return NextResponse.json({
+    success: true,
+    recipients: await getNotificationRecipients(),
+    envAdminEmails: getEnvAdminEmails(),
+    smtpConfigured: Boolean(process.env.SMTP_HOST),
+  });
+}
+
+export async function PUT(req: NextRequest) {
+  const authError = verifyAdmin(req);
+  if (authError) return authError;
+
+  let body: { recipients?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ success: false, message: "Invalid JSON." }, { status: 400 });
+  }
+  if (!Array.isArray(body.recipients)) {
+    return NextResponse.json(
+      { success: false, message: "Body must be { recipients: string[] }." },
+      { status: 400 },
+    );
+  }
+
+  const result = await setNotificationRecipients(body.recipients.map(String));
+  if (!result.ok) {
+    return NextResponse.json(
+      { success: false, message: result.error || "Failed to save recipients." },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json({ success: true, recipients: result.recipients });
+}
+
+export async function POST(req: NextRequest) {
+  const authError = verifyAdmin(req);
+  if (authError) return authError;
+
+  const targets = await getLeadNotificationTargets();
+  if (targets.length === 0) {
+    return NextResponse.json(
+      { success: false, message: "No recipients configured yet — add one and save first." },
+      { status: 400 },
+    );
+  }
+
+  const fromAddress = process.env.EMAIL_FROM || "noreply@valorlegacies.com";
+  const companyName = process.env.COMPANY_NAME || "Valor Legacies";
+  const subject = `Test — ${companyName} lead notifications`;
+  const text =
+    "This is a test of your new-lead notifications. If you received this, alerts are wired correctly.";
+  const html = `<p>This is a <strong>test</strong> of your new-lead notifications.</p><p>If you received this, alerts are wired correctly.</p>`;
+
+  const results = await Promise.allSettled(
+    targets.map((to) => sendEmail({ to, from: fromAddress, subject, text, html })),
+  );
+  const sent = results.filter((r) => r.status === "fulfilled").length;
+  const failed = results.length - sent;
+  const smtpConfigured = Boolean(process.env.SMTP_HOST);
+
+  return NextResponse.json({
+    success: true,
+    sent,
+    failed,
+    targets,
+    smtpConfigured,
+    note: smtpConfigured
+      ? undefined
+      : "SMTP is not configured (SMTP_HOST unset) — emails are logged to the server console, not delivered. Set SMTP_HOST/USER/PASS in Vercel to send for real.",
+  });
+}

--- a/digital-cathedral/app/components/navbar.tsx
+++ b/digital-cathedral/app/components/navbar.tsx
@@ -94,6 +94,8 @@ export function Navbar() {
   const menuLinks = isAdmin
     ? [
         { href: adminHref, label: "Admin Dashboard" },
+        { href: `${portalBaseUrl}/admin/leads`, label: "All Leads" },
+        { href: `${portalBaseUrl}/admin/notifications`, label: "Notifications" },
         { href: `${portalBaseUrl}/admin/patterns`, label: "Pattern Library" },
         { href: `${portalBaseUrl}/portal`, label: "Agent Portal" },
         { href: "/", label: "Public Home" },

--- a/digital-cathedral/app/lib/email.ts
+++ b/digital-cathedral/app/lib/email.ts
@@ -15,6 +15,7 @@
  */
 
 import { withCircuitBreaker, CircuitOpenError } from "./circuit-breaker";
+import { getLeadNotificationTargets } from "./notification-recipients";
 
 // --- Retry with exponential backoff for delivery ---
 async function retry<T>(
@@ -250,8 +251,10 @@ export async function sendAdminNotificationEmail(lead: {
   veteranStatus: string;
   leadId: string;
 }, score?: { total: number; tier: string }): Promise<void> {
-  const adminEmail = process.env.ADMIN_EMAIL;
-  if (!adminEmail) return; // No admin email configured — skip silently
+  // Recipients = the admin-managed list (set in /admin/notifications) merged
+  // with the legacy ADMIN_EMAIL env var. Empty → nobody to notify, skip.
+  const recipients = await getLeadNotificationTargets();
+  if (recipients.length === 0) return;
 
   const companyName = getCompanyName();
   const fromAddress = getFromAddress();
@@ -343,10 +346,13 @@ export async function sendAdminNotificationEmail(lead: {
 
   try {
     await withCircuitBreaker(
-      () => sendEmail({ to: adminEmail, from: fromAddress, subject, text, html }),
+      () =>
+        Promise.all(
+          recipients.map((to) => sendEmail({ to, from: fromAddress, subject, text, html })),
+        ),
       { name: "email-admin", failureThreshold: 5, resetTimeout: 60_000 },
     );
-    console.log(`[EMAIL] Admin notification sent for lead ${lead.leadId}`);
+    console.log(`[EMAIL] Admin notification sent for lead ${lead.leadId} to ${recipients.length} recipient(s)`);
   } catch (err) {
     if (err instanceof CircuitOpenError) {
       console.warn(`[EMAIL] Circuit open — skipping admin email for lead ${lead.leadId}. ${err.message}`);

--- a/digital-cathedral/app/lib/notification-recipients.ts
+++ b/digital-cathedral/app/lib/notification-recipients.ts
@@ -1,0 +1,76 @@
+/**
+ * Lead-notification recipients.
+ *
+ * The admin-managed list of email addresses that get notified when a new lead
+ * is submitted. Stored durably via the site-content key/value store (Postgres
+ * or the substrate in production — NOT the ephemeral pricing-config JSON file,
+ * which doesn't survive Vercel's serverless filesystem).
+ *
+ * The send path (sendAdminNotificationEmail) uses getLeadNotificationTargets(),
+ * which merges this list with the legacy ADMIN_EMAIL env var so existing
+ * deployments keep working while the dashboard becomes the primary control.
+ */
+
+import { getDbSiteContent, setDbSiteContent } from "./database";
+
+const RECIPIENTS_KEY = "lead_notification_recipients";
+
+/** Pragmatic email check — good enough to reject typos and junk, not RFC-perfect. */
+export function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+/** Trim, lowercase, drop invalid/blank, dedupe — order-preserving. */
+export function normalizeEmails(input: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input) {
+    const email = String(raw).trim().toLowerCase();
+    if (!email || !isValidEmail(email) || seen.has(email)) continue;
+    seen.add(email);
+    out.push(email);
+  }
+  return out;
+}
+
+/** The admin-managed recipient list (stored). Empty array when none/unset. */
+export async function getNotificationRecipients(): Promise<string[]> {
+  const res = await getDbSiteContent(RECIPIENTS_KEY);
+  if (!res.ok || !res.value) return [];
+  try {
+    const parsed = JSON.parse(res.value);
+    return Array.isArray(parsed) ? normalizeEmails(parsed) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Replace the stored recipient list (validated + deduped). */
+export async function setNotificationRecipients(
+  emails: readonly string[],
+): Promise<{ ok: boolean; recipients: string[]; error?: string }> {
+  const recipients = normalizeEmails(emails);
+  const res = await setDbSiteContent(RECIPIENTS_KEY, JSON.stringify(recipients));
+  if (!res.ok) return { ok: false, recipients: [], error: res.error };
+  return { ok: true, recipients };
+}
+
+/** Comma-split, normalize the legacy ADMIN_EMAIL env var (may hold several). */
+function envAdminEmails(): string[] {
+  return normalizeEmails((process.env.ADMIN_EMAIL || "").split(","));
+}
+
+/** Read-only view of the env fallback, for display in the admin UI. */
+export function getEnvAdminEmails(): string[] {
+  return envAdminEmails();
+}
+
+/**
+ * The full set of addresses to notify on a new lead: the admin-managed list
+ * merged with the legacy ADMIN_EMAIL env var, deduped. This is the authority
+ * the send path uses.
+ */
+export async function getLeadNotificationTargets(): Promise<string[]> {
+  const stored = await getNotificationRecipients();
+  return normalizeEmails([...stored, ...envAdminEmails()]);
+}


### PR DESCRIPTION
Two requested admin features.

1) Easily-accessible all-leads list (app/admin/leads/page.tsx)
   /admin/leads was a bare redirect to the (busy) dashboard. It's now a focused,
   always-accessible list of every submitted lead: search by name/email, filter
   by source, paginate, and export CSV — reading the same /api/admin/leads the
   dashboard uses. Reached via new 'All Leads' buttons on the dashboard and the
   navbar admin menu. (Only admitted leads are stored; bot/fraud are rejected at
   the gate and never persist — so this is the full real list.)

2) Admin-managed new-lead notification recipients
   - app/lib/notification-recipients.ts: durable recipient list stored via the site-content KV store (Postgres/substrate — survives Vercel restarts, unlike the ephemeral pricing-config file). Validates, lowercases, dedupes. getLeadNotificationTargets() merges the managed list with the legacy ADMIN_EMAIL env var so existing setups keep working.
   - email.ts: sendAdminNotificationEmail() now fans out to every target (Promise.all inside the existing circuit breaker) instead of the single ADMIN_EMAIL. Empty list → skip, unchanged.
   - GET/PUT/POST /api/admin/notifications: load list, save list, and send a test notification to all targets (the test also reports whether SMTP is configured, so the operator can confirm delivery).
   - app/admin/notifications/page.tsx: add/remove recipients, save, send test; shows the read-only ADMIN_EMAIL fallback and warns when SMTP is unset. Reached via new 'Notifications' buttons on the dashboard and navbar.

typecheck + lint clean; goggles: no meta-debug findings, all CONSONANT.


Claude-Session: https://claude.ai/code/session_01XeuEWbZGDznSTjSePTMC6L