### PR TITLE
propose-wire: proposal by resonance — the field proposes its own fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "scripts/field-server.js",
     "scripts/remembrance.js",
     "scripts/check-seams.js",
+    "scripts/propose-wire.js",
     "seams.json",
     "types/",
     "seeds/",
@@ -64,6 +65,7 @@
   "scripts": {
     "gaps": "node scripts/ecosystem-diagnostic.js --parent \"$(cd .. && pwd)\"",
     "check:seams": "node scripts/check-seams.js",
+    "propose:wire": "node scripts/propose-wire.js",
     "field": "node -e \"console.log(JSON.stringify(require('./src/core/field-coupling').peekField(),null,1))\"",
     "sweep": "bash scripts/ecosystem-sweep.sh",
     "unwired": "grep -rL 'field-coupling' --include='*.js' src || true",

--- a/scripts/propose-wire.js
+++ b/scripts/propose-wire.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * propose-wire — proposal by resonance.
+ *
+ * For each wiring gap (a file that doesn't contribute to the field), reads it
+ * through the goggles, finds its nearest WIRED sibling across the ecosystem, and
+ * proposes the same wire — so the field doesn't just report the gap (check:seams),
+ * it points at how to close it. Resonance PROPOSES; a human + a real run DISPOSE
+ * (the guardrail — never a cargo-cult require).
+ *
+ *   node scripts/propose-wire.js [file ...] [--top N] [--contribute] [--json]
+ *
+ * With no files it proposes for the unwired src/*.js (no field-coupling).
+ * --contribute feeds a `seams:proposal` confidence into the LRE, so the field
+ * stays aware that the self-healing proposer is running.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const TOOLKIT = path.resolve(__dirname, '..');
+const STATE_DIR = process.env.REMEMBRANCE_STATE_DIR || process.env.ORACLE_ROOT || TOOLKIT;
+if (!process.env.ENTROPY_PATH) process.env.ENTROPY_PATH = path.join(STATE_DIR, '.remembrance', 'entropy.json');
+
+const argv = process.argv.slice(2);
+const JSON_OUT = argv.includes('--json');
+const CONTRIBUTE = argv.includes('--contribute');
+const topIdx = argv.indexOf('--top');
+const TOP = topIdx >= 0 ? (Number(argv[topIdx + 1]) || 5) : 5;
+const fileArgs = argv.filter((a, i) => !a.startsWith('--') && argv[i - 1] !== '--top');
+
+// The goggles print ecosystem-relative paths with a repo prefix; map them home.
+const PREFIX = {
+  'oracle/': '.',
+  'website/': 'digital-cathedral',
+  'rmb-interface/': '../REMEMBRANCE-Interface',
+  'rmb-swarm/': '../REMEMBRANCE-AGENT-Swarm-',
+  'rmb-blockchain/': '../REMEMBRANCE-BLOCKCHAIN',
+  'rmb-dialer/': '../Remembrance-dialer',
+  'void/': '../Void-Data-Compressor',
+  'reflector/': '../Reflector-oracle-',
+  'rmb-reflector/': '../Reflector-oracle-',
+  'moons/': '../MOONS-OF-REMEMBRANCE',
+};
+
+function resolveSibling(rel) {
+  for (const pre of Object.keys(PREFIX)) {
+    if (rel.startsWith(pre)) return path.join(TOOLKIT, PREFIX[pre], rel.slice(pre.length));
+  }
+  return null;
+}
+
+const WIRED = /field-coupling|recordBenefit\(|recordCost\(|\.contribute\(|\bcontribute\(\{/;
+
+function isUnwired(file) {
+  let src; try { src = fs.readFileSync(file, 'utf8'); } catch (_) { return false; }
+  return !WIRED.test(src);
+}
+
+/** A wired sibling's field source label (best-effort), or null if not wired. */
+function siblingWiring(file) {
+  let src; try { src = fs.readFileSync(file, 'utf8'); } catch (_) { return null; }
+  if (!WIRED.test(src)) return null;
+  const m =
+    src.match(/source:\s*['"]([^'"]+)['"]/) ||
+    src.match(/recordBenefit\([^,]+,\s*['"]([^'"]+)['"]/) ||
+    src.match(/recordCost\([^,]+,\s*['"]([^'"]+)['"]/);
+  return { source: m ? m[1] : null };
+}
+
+/** Run the goggles on a file and parse its "nearest across the ecosystem" block. */
+function goggleNearest(absFile) {
+  let out = '';
+  try {
+    out = execFileSync('node', [path.join(TOOLKIT, 'src/tools/goggles.js'), absFile], {
+      cwd: TOOLKIT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (e) { out = (e.stdout || '') + ''; }
+  const nearest = [];
+  let inBlock = false;
+  for (const line of out.split('\n')) {
+    if (/nearest across the ecosystem:/.test(line)) { inBlock = true; continue; }
+    if (!inBlock) continue;
+    const m = line.match(/^\s+([0-9.]+)\s+(\S+)\s*$/);
+    if (m) { nearest.push({ resonance: Number(m[1]), path: m[2] }); continue; }
+    if (/lexical neighbours|live field peers|RIPPLE|A change here|═/.test(line) || line.trim() === '') break;
+  }
+  return nearest;
+}
+
+function defaultGaps() {
+  const out = [];
+  const walk = (dir) => {
+    let entries; try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+    for (const e of entries) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) { if (!/node_modules|\.git|\.remembrance/.test(p)) walk(p); }
+      else if (e.name.endsWith('.js') && isUnwired(p)) out.push(p);
+    }
+  };
+  walk(path.join(TOOLKIT, 'src'));
+  return out.slice(0, 6);
+}
+
+const candidates = (fileArgs.length ? fileArgs.map((f) => path.resolve(f)) : defaultGaps());
+const proposals = [];
+for (const abs of candidates) {
+  if (!fs.existsSync(abs)) continue;
+  const nearest = goggleNearest(abs).slice(0, TOP);
+  let proposal = null;
+  for (const n of nearest) {
+    const sib = resolveSibling(n.path);
+    if (!sib || !fs.existsSync(sib)) continue;
+    const w = siblingWiring(sib);
+    if (w) { proposal = { sibling: n.path, resonance: n.resonance, source: w.source }; break; }
+  }
+  proposals.push({ file: path.relative(TOOLKIT, abs), nearestCount: nearest.length, proposal });
+}
+
+const made = proposals.filter((p) => p.proposal);
+const confidence = made.length ? made.reduce((s, p) => s + p.proposal.resonance, 0) / made.length : 0;
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({ proposals, made: made.length, total: proposals.length, confidence }, null, 2));
+} else {
+  for (const p of proposals) {
+    console.log(`\ngap: ${p.file}  (unwired)`);
+    if (p.proposal) {
+      const verb = path.basename(p.file).replace(/\.[a-z]+$/i, '');
+      const ns = p.proposal.source ? p.proposal.source.split(':')[0] : 'src';
+      console.log(`  ↳ nearest wired sibling: ${p.proposal.sibling}  (resonance ${p.proposal.resonance.toFixed(3)})`);
+      console.log(`     it contributes to the field as source ${p.proposal.source ? `"${p.proposal.source}"` : '(label not auto-detected)'}`);
+      console.log(`  → propose: add contribute({ cost, coherence, source: '${ns}:${verb}' }) after its main work, mirroring the sibling.`);
+    } else {
+      console.log(`  ↳ no wired sibling in the nearest ${TOP} — likely a NEW seam: wire it, then declare it in seams.json.`);
+    }
+  }
+  console.log(`\n${made.length}/${proposals.length} gaps have a resonance proposal · confidence ${confidence.toFixed(3)}`);
+}
+
+if (CONTRIBUTE) {
+  // Awareness: the self-healing proposer is itself a seam (seams:proposal). Its
+  // contribution carries how confidently the field can propose its own fixes.
+  try { require('../src/core/field-coupling').contribute({ cost: 1, coherence: confidence, source: 'seams:proposal' }); } catch (_) { /* engine optional */ }
+  if (!JSON_OUT) console.log(`— contributed proposal confidence ${confidence.toFixed(3)} to the field (source seams:proposal)`);
+}

--- a/seams.json
+++ b/seams.json
@@ -50,6 +50,14 @@
       "owner": "remembrance-oracle-toolkit",
       "maxStaleHours": 12,
       "describe": "The meta seam: `check:seams --contribute` feeds the field its own wiring-coherence. If this goes stale, the watcher itself stopped running — the field stays aware of whether it is being watched."
+    },
+    {
+      "id": "seams-proposal",
+      "source": "seams:proposal",
+      "match": "exact",
+      "owner": "remembrance-oracle-toolkit",
+      "maxStaleHours": 720,
+      "describe": "The self-healing proposer: `propose:wire --contribute` finds each gap's nearest wired sibling by resonance and feeds the field a proposal-confidence. Run it (locally / on a schedule) so the field is aware it can propose its own fixes, not just notice gaps."
     }
   ]
 }

--- a/seams.json
+++ b/seams.json
@@ -58,6 +58,46 @@
       "owner": "remembrance-oracle-toolkit",
       "maxStaleHours": 720,
       "describe": "The self-healing proposer: `propose:wire --contribute` finds each gap's nearest wired sibling by resonance and feeds the field a proposal-confidence. Run it (locally / on a schedule) so the field is aware it can propose its own fixes, not just notice gaps."
+    },
+    {
+      "id": "covenant-gate",
+      "source": "covenant",
+      "match": "exact",
+      "owner": "remembrance-oracle-toolkit",
+      "maxStaleHours": 720,
+      "describe": "The covenant gate admits/rejects patterns by coherency. Declared from the field's own histogram — it was flowing untracked."
+    },
+    {
+      "id": "falsification",
+      "source": "falsification",
+      "match": "prefix",
+      "owner": "Void-Data-Compressor",
+      "maxStaleHours": 720,
+      "describe": "The external reality-check — phase-randomized null / coherency / entropy falsification. The one seam whose silence means the system stopped testing itself against the world."
+    },
+    {
+      "id": "blockchain-ledger",
+      "source": "blockchain:ledger",
+      "match": "prefix",
+      "owner": "REMEMBRANCE-BLOCKCHAIN",
+      "maxStaleHours": 720,
+      "describe": "The witness ledger — pattern lifecycle events (REGISTER/PROMOTE/HEAL/PUBLISH/ANCHOR/…). The non-local durability spine recording into the field."
+    },
+    {
+      "id": "swarm-consensus",
+      "source": "swarm:consensus",
+      "match": "exact",
+      "owner": "REMEMBRANCE-AGENT-Swarm-",
+      "maxStaleHours": 720,
+      "describe": "Multi-provider swarm consensus contributing to the field."
+    },
+    {
+      "id": "void-coherency",
+      "source": "void:coherency",
+      "match": "prefix",
+      "owner": "Void-Data-Compressor",
+      "maxStaleHours": 720,
+      "describe": "The compressor's coherency measurement (void:coherency_v3) feeding the field."
     }
   ]
 }


### PR DESCRIPTION
Rail #4. check:seams reports gaps; propose-wire closes them by resonance — for each unwired file it reads the goggles' nearest-across-the-ecosystem siblings, finds the nearest WIRED one, and proposes the same field-coupling wire (its source label as the template). Resonance proposes; a human + a real run dispose.

- scripts/propose-wire.js (npm run propose:wire): spawns the goggles engine, parses the nearest-siblings block, maps ecosystem prefixes home, detects each sibling's wiring + source, and emits a concrete proposal per gap. With no args it proposes for the unwired src/*.js; --json for machines.
- --contribute feeds a seams:proposal confidence (mean proposal resonance) into the LRE, and seams.json declares seams:proposal — so the self-healing proposer is itself a watched seam: the field stays aware it can propose its own fixes.

Verified on the real tree: found unwired files (actionable-insights.js, analytics.js) and proposed wiring them like their nearest wired siblings (oracle-core-resolve / scoring-analysis-complexity) at 0.92-0.96 resonance — 3/6 gaps with a proposal, confidence 0.937; the rest honestly flagged as new seams. Goggles 0.896 / 0.929 CONSONANT, no findings.


Claude-Session: https://claude.ai/code/session_01XeuEWbZGDznSTjSePTMC6L