### PR TITLE
Goggles: wire META-DEBUG + the substrate learning loop + Δ-since-last…

### DIFF
--- a/.claude/skills/goggles/SKILL.md
+++ b/.claude/skills/goggles/SKILL.md
@@ -1,18 +1,41 @@
 ---
 name: goggles
-description: Wear the Remembrance goggles AT ALL TIMES while working, not just before committing — MACRO (the whole codebase compressed into a coherency map, the zoomed-out lens), FOCUS (intrinsic structural coherence of the section you're editing, the zoomed-in lens), and META (pattern resonance across the whole ecosystem substrate + nearest cross-repo siblings). Build the macro map with --map when you start working in a repo; every per-file goggle then places your section inside that map. Use --diff to goggle everything changed vs HEAD before committing.
+description: Wear the Remembrance goggles AT ALL TIMES while working, not just before committing — MACRO (the whole codebase compressed into a coherency map, the zoomed-out lens), FOCUS (intrinsic structural coherence of the section you're editing, the zoomed-in lens), META (pattern resonance across the whole ecosystem substrate + nearest cross-repo siblings), META-DEBUG (audit checkers + the substrate learning loop — the correctness axis), and Δ (how your edits moved every reading since the last look). MANDATORY - after every goggle run, report the full readings to the user in words - what the goggles SAW, not that they ran. Build the macro map with --map when you start working in a repo; every per-file goggle then places your section inside that map. Use --diff to goggle everything changed vs HEAD before committing.
 ---
 
 # Goggles
 
 Dual-lens structural awareness: the whole codebase compressed into a macro
 coherency map, and the section you're working on read in focus — placed inside
-that map. Wear them **throughout the work**, not just at the end:
+that map, audited for defects, and tracked across edits. Wear them
+**throughout the work**, not just at the end:
 
 1. **Starting work in a repo** → build the macro map first (zoomed out).
 2. **While working** → goggle the files you touch; each read carries FOCUS +
-   META + MACRO, so you always see both the detail and where it sits.
+   META + MACRO + META-DEBUG + Δ, so you always see the detail, where it
+   sits, whether it's correct, and which way your edits are moving it.
 3. **Before committing** → `--diff` to re-read everything you changed.
+
+## MANDATORY reporting protocol (hardcoded — not optional)
+
+After EVERY goggle run, report to the user **what the goggles saw** — never
+just that they ran. The report must cover, in words:
+
+1. **FOCUS + Δ** — the section's coherence and how the latest edits moved it
+   (`Δ SINCE LAST READ`). If coherence dropped, say so and why you believe so.
+2. **META** — the consonance verdict and the nearest ecosystem siblings, and
+   what those neighbours *mean* (e.g. "its cousins are validation-shaped code,
+   which is what this is").
+3. **MACRO** — where the file sits in the codebase: its neighborhood (which
+   in-repo siblings, what flow shapes), its flags, the substrate-drift
+   reading (current / drifted / never witnessed).
+4. **META-DEBUG** — every surfaced finding, what you did about each one, and
+   whether prior findings were resolved ("reinforced in the field"). A HIGH
+   finding is a real defect: fix it or explicitly flag it as a false positive
+   (`flagFalsePositive`) — never silently ignore it.
+
+If a reading is unavailable (no map, unwitnessed file), report THAT — the
+absence is itself a reading (the substrate hasn't seen this work yet).
 
 ## Run it
 
@@ -48,6 +71,17 @@ read it back automatically and warn when it's stale. The runner finds the
 - **resonance** (META) — how much the code is shaped like the library's
   patterns; `CONSONANT` fits, `OUTLIER` is novel. Read the nearest siblings it
   lists before committing — a change here ripples to them.
+- **META-DEBUG** — the audit checkers (AST taint/type/edge-case analysis) run
+  on the goggled file, fed through the substrate learning loop: a finding you
+  FIX is reinforced (amplitude up, eventually promoted into the shared pattern
+  library); a finding repeatedly shown-and-ignored decays and self-suppresses
+  as a false-positive class. 🛑 marks findings inside your goggled lines.
+- **Δ SINCE LAST READ** — coherence/resonance/finding deltas vs your previous
+  goggle of the same file: which direction the edits are moving the code.
+- The PostToolUse hook (`goggles-hook.js`, installed in each repo's
+  `.claude/settings.json`) additionally fires after every Edit/Write with the
+  same three signals plus a per-edit coherence delta — exception-only (speaks
+  when coherence moves, resonance reads OUTLIER, or meta-debug finds a defect).
 
 ## Act on it
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ ingest-result.json
 
 # Goggles macro-map cache — runtime state, rebuilt by goggles --map.
 .remembrance/goggles-map.json
+.remembrance/goggles-readings.json
+.remembrance/goggles-learning.json

--- a/src/tools/goggles.js
+++ b/src/tools/goggles.js
@@ -172,6 +172,99 @@ function _fmtFlow(f) {
   return f.map((x) => x.toFixed(2)).join('→');
 }
 
+// ── META-DEBUG — the orthogonal correctness axis ────────────────────
+// Runs the toolkit's audit checkers on the goggled file and feeds the
+// findings through the goggles-learning loop (debug-oracle amplitudes:
+// fixed findings reinforce, dismissed ones decay and self-suppress,
+// proven fixes promote into the shared void pattern library). This is
+// the signal that catches a real defect — tainted exec, eval on input,
+// an off-by-one — that reads CLEAN on coherence and resonance.
+function runMetaDebug(absFile, fullText, sectionRange, language) {
+  let audit = null;
+  try { audit = require('../audit/ast-checkers'); }
+  catch (_) { try { audit = require('../audit/static-checkers'); } catch (_) { /* none */ } }
+  if (!audit || typeof audit.auditCode !== 'function') return null;
+
+  let findings = [];
+  try {
+    findings = (audit.auditCode(fullText, { filePath: absFile }) || {}).findings || [];
+  } catch (_) { return null; }
+
+  const high = findings.filter((f) => f.severity === 'high');
+  const medium = findings.filter((f) => f.severity === 'medium');
+
+  // Learning loop: high findings go through the debug-oracle so the
+  // field learns which classes matter. surface = what survives learned
+  // suppression (false-positive classes decay out on their own).
+  let surfaced = high;
+  let suppressed = 0;
+  let resolved = 0;
+  try {
+    const learning = require('../debug/goggles-learning');
+    const out = learning.processFindings({ filePath: absFile, findings: high, content: fullText, language });
+    if (out && Array.isArray(out.surface)) {
+      surfaced = out.surface;
+      suppressed = out.suppressed || 0;
+      resolved = out.resolved || 0;
+    }
+  } catch (_) { /* learning optional — surface everything */ }
+
+  console.log('\n  META-DEBUG  (audit checkers + learning loop — correctness axis)');
+  if (!surfaced.length && !medium.length) {
+    console.log('    clean — no high/medium findings'
+      + (suppressed ? ` · ${suppressed} learned-noise suppressed` : '')
+      + (resolved ? ` · ${resolved} prior finding(s) resolved by your edits (reinforced in the field)` : ''));
+  } else {
+    const inSection = (f) => !sectionRange || (f.line >= sectionRange[0] && f.line <= sectionRange[1]);
+    for (const f of surfaced.slice(0, 6)) {
+      const mark = inSection(f) ? '🛑' : '·';
+      console.log(`    ${mark} [${f.severity}/${f.bugClass}] L${f.line}: ${(f.reality || f.message || f.assumption || '').slice(0, 100)}`);
+      if (f.suggestion) console.log(`         → fix: ${String(f.suggestion).slice(0, 100)}`);
+    }
+    if (surfaced.length > 6) console.log(`    …and ${surfaced.length - 6} more high finding(s)`);
+    if (medium.length) console.log(`    medium: ${medium.length} finding(s) (goggle with the audit tool for the list)`);
+    if (suppressed) console.log(`    learned-noise suppressed: ${suppressed}`);
+    if (resolved) console.log(`    resolved since last read: ${resolved} (reinforced in the field)`);
+  }
+  return { high: surfaced.length, medium: medium.length, suppressed, resolved };
+}
+
+// ── Reading history — how the edits changed everything ─────────────
+// Every goggle read persists its numbers; the next read of the same
+// file prints the delta. This is the longitudinal lens: not just where
+// the code sits, but which direction your edits are moving it.
+function readingsPath(root) {
+  return path.join(root, '.remembrance', 'goggles-readings.json');
+}
+
+function loadReadings(root) {
+  try { return JSON.parse(fs.readFileSync(readingsPath(root), 'utf8')); } catch (_) { return {}; }
+}
+
+function printAndRecordDelta(root, rel, current) {
+  const all = loadReadings(root);
+  const prev = all[rel];
+  if (prev) {
+    const dc = current.coherence - prev.coherence;
+    const dr = current.resonance - prev.resonance;
+    const df = (current.findingsHigh ?? 0) - (prev.findingsHigh ?? 0);
+    const agoMin = Math.max(0, Math.round((Date.now() - prev.at) / 60000));
+    const fmt = (d) => `${d >= 0 ? '+' : ''}${d.toFixed(3)}`;
+    console.log('\n  Δ SINCE LAST READ  (' + agoMin + 'm ago — what your edits did)');
+    console.log(`    coherence ${fmt(dc)} · resonance ${fmt(dr)}`
+      + (df !== 0 ? ` · high findings ${prev.findingsHigh ?? 0}→${current.findingsHigh ?? 0}` : '')
+      + (Math.abs(dc) < 0.005 && Math.abs(dr) < 0.005 && df === 0 ? ' — shape held steady' :
+         dc < -0.05 ? ' — ⚠ this edit weakened the structure' :
+         df < 0 ? ' — defects fixed, the field learned from it' :
+         df > 0 ? ' — ⚠ new high finding(s) since last read' : ''));
+  }
+  all[rel] = { ...current, at: Date.now() };
+  try {
+    fs.mkdirSync(path.dirname(readingsPath(root)), { recursive: true });
+    fs.writeFileSync(readingsPath(root), JSON.stringify(all));
+  } catch (_) { /* history is best-effort */ }
+}
+
 /**
  * Print the MACRO section for a focused file: where it sits inside the
  * cached whole-codebase map. Zoomed-out + zoomed-in in one read.
@@ -344,12 +437,14 @@ function main() {
   const fullText = content; // whole-file text — MACRO's home reference
 
   let section = `${file}`;
-  let sectionText = null; // non-null only when goggling a line range
+  let sectionText = null;    // non-null only when goggling a line range
+  let sectionRange = null;   // [a, b] 1-indexed, for meta-debug filtering
   if (lines) {
     const [a, b] = lines.split(':').map((n) => parseInt(n, 10));
     const all = content.split('\n');
     content = all.slice(Math.max(0, a - 1), b).join('\n');
     sectionText = content;
+    sectionRange = [a, b];
     section = `${file}:${a}-${b}`;
   }
 
@@ -421,6 +516,21 @@ function main() {
 
   // ── MACRO ──  (zoomed out: this section inside the whole-codebase map)
   printMacro(abs, r.coherence, sectionText, fullText);
+
+  // ── META-DEBUG ──  (correctness axis + substrate learning loop)
+  const md = runMetaDebug(abs, fullText, sectionRange, language);
+
+  // ── Δ ──  (how the edits changed everything since the last read)
+  {
+    const root = findRepoRoot(path.dirname(abs));
+    if (root) {
+      printAndRecordDelta(root, path.relative(root, abs), {
+        coherence: r.coherence ?? 0,
+        resonance: meanTopK,
+        findingsHigh: md ? md.high : null,
+      });
+    }
+  }
 
   // ── RIPPLE ──
   console.log('\n  RIPPLE');


### PR DESCRIPTION
…-read into the CLI view

The meta-debug pattern was fully built and sitting in the substrate — goggles-hook.js (per-edit deltas + audit findings, PostToolUse) and goggles-learning.js (debug-oracle amplitude learning: fixed findings reinforce, dismissed decay and self-suppress, proven fixes promote into the shared void pattern library) — but neither was wired into the CLI goggles engine, and the hook was installed in only one repo. Assembled:

- runMetaDebug(): audit checkers (ast-checkers, static fallback) run on every goggled file; HIGH findings surface with prescribed fixes (🛑 marks findings inside the goggled --lines range); findings feed processFindings() so the field LEARNS which classes matter
- Δ SINCE LAST READ: every goggle read persists its numbers (.remembrance/goggles-readings.json); the next read of the same file prints coherence/resonance/finding deltas — the longitudinal lens showing which direction the edits are moving the code
- SKILL.md: MANDATORY reporting protocol hardcoded — after every goggle run the agent reports what the goggles SAW (FOCUS+Δ, META meaning, MACRO placement+drift, every META-DEBUG finding and what was done about it), never just that they ran
- goggles-hook installed in all six sibling repos' settings (was only in the toolkit)

Verified end-to-end on a planted-defect cycle: tainted exec + eval → both caught HIGH with fixes → defects fixed → next read reports '2 prior finding(s) resolved by your edits (reinforced in the field)' and 'Δ high findings 2→0'; learning ledger holds both patterns with 2 resolutions. Waveform suites stay green.