### PR TITLE
Homepage polish: full-frame card videos, remove spouse clip, uncrop founder photo

### DIFF
--- a/digital-cathedral/app/page.tsx
+++ b/digital-cathedral/app/page.tsx
@@ -64,7 +64,7 @@ const LIFE_CHAPTERS: { icon: string; title: string; desc: string; cta: string; v
   { icon: "✦", title: "Just Had a Baby", desc: "Your family just grew. Now is the time to protect the future they’re just beginning.", cta: "Protect My Growing Family", value: "new-baby", video: "newborn-parents.mp4" },
   { icon: "⌂", title: "Bought a Home", desc: "Your home is more than a mortgage. It’s where your family’s life is being built.", cta: "Protect My Home", value: "bought-home", video: "new-home.mp4" },
   { icon: "∞", title: "Recently Married", desc: "You’re building a future together. Protection helps keep that future secure.", cta: "Start Planning Together", value: "recently-married", video: "newly-married.mp4" },
-  { icon: "❤", title: "Protecting My Spouse", desc: "If someone depends on your income, love means having a plan.", cta: "Protect My Person", value: "protect-spouse-family", video: "family-embracing.mp4" },
+  { icon: "❤", title: "Protecting My Spouse", desc: "If someone depends on your income, love means having a plan.", cta: "Protect My Person", value: "protect-spouse-family" },
   { icon: "$", title: "Protecting My Income", desc: "Your income supports your life. Protecting it protects the people who rely on you.", cta: "Review Income Protection", value: "income-replacement" },
   { icon: "◈", title: "Preparing for College", desc: "Plan for tomorrow’s dreams while protecting today’s responsibilities.", cta: "Explore Education Planning", value: "college-planning" },
   { icon: "☼", title: "Planning Retirement", desc: "Retirement should come with confidence, flexibility, and peace of mind.", cta: "Plan With Confidence", value: "retirement-planning" },
@@ -294,7 +294,7 @@ export default function HomePage() {
             {LIFE_CHAPTERS.map((chapter) => (
               <button key={chapter.title} type="button" onClick={() => chooseChapter(chapter.value)} className="group overflow-hidden rounded-[1.5rem] border border-[#decda9] bg-white/80 p-5 text-left shadow-[0_18px_60px_rgba(61,43,24,0.08)] transition-all hover:-translate-y-1 hover:border-[#c8a85d] hover:bg-white hover:shadow-[0_26px_70px_rgba(61,43,24,0.14)] focus-visible:outline-[#b58b3b]">
                 {chapter.video && (
-                  <div className="-mx-5 -mt-5 mb-5 h-36 overflow-hidden motion-reduce:hidden">
+                  <div className="-mx-5 -mt-5 mb-5 aspect-[464/688] overflow-hidden bg-[#241d15] motion-reduce:hidden">
                     <video className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" autoPlay muted loop playsInline preload="metadata" aria-hidden="true">
                       <source src={`/assets/valor/${chapter.video}`} type="video/mp4" />
                     </video>
@@ -598,7 +598,7 @@ export default function HomePage() {
             <a href="/about" className="mt-8 inline-flex rounded-full bg-[#d6b35f] px-7 py-3 text-sm font-semibold text-[#241d15]">Our Story</a>
           </div>
           <figure className="overflow-hidden rounded-[1.5rem] border border-[#d6b35f]/40 bg-gradient-to-br from-[#f6e5c4]/15 to-[#b58b3b]/10 p-3 shadow-[0_30px_90px_rgba(0,0,0,0.35)]">
-            <img src="/assets/valor/founder-andrea-military.jpg" alt="Andrea Golden, veteran and founder of Valor Legacies" className="aspect-[4/5] w-full rounded-[1.15rem] object-cover object-top" loading="lazy" />
+            <img src="/assets/valor/founder-andrea-military.jpg" alt="Andrea Golden, veteran and founder of Valor Legacies" className="w-full rounded-[1.15rem]" loading="lazy" />
             <figcaption className="px-2 pb-1 pt-4 text-center">
               <p className="font-serif text-2xl text-[#f6e5c4]">Andrea Golden</p>
               <p className="mt-1 text-xs uppercase tracking-[0.24em] text-[#d6b35f]">Founder · Veteran</p>


### PR DESCRIPTION
Follow-up to #260 (already merged), addressing preview feedback. Homepage-only; form, consent, and submission logic untouched.

## Changes

**Card videos now show the full frame**
- The clips are 464×688 (portrait); the previous fixed `h-36` box cropped them. The card media area now uses the video's exact aspect ratio (`aspect-[464/688]`), so `object-cover` renders the whole frame with no crop and no letterbox bars — and the video becomes the dominant part of the card. Cards stay silent/muted/loop (no audio, by request). A charcoal backdrop covers the brief load moment.

**Removed the "Protecting My Spouse" card video**
- That card is icon-only again. `family-embracing.mp4` is no longer referenced on the homepage (file kept in `public/assets/valor/` in case it's wanted for a future section).

**Founder photo uncropped**
- The photo is 1088×944 (landscape/near-square) but was forced into a `4/5` portrait crop with `object-top`, cutting the sides. It now renders at its natural ratio in the cream/gold frame, so the whole photo shows.

## Verification
- `tsc --noEmit` clean.
- Structural goggles: CONSONANT (0.936), meta-debug clean, shape held steady.
- Preview build on this branch's alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW

---
_Generated by [Claude Code](https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW)_