### PR TITLE
Homepage: grey-gradient Trust Pillars, navy Protection Path

### DIFF
--- a/digital-cathedral/app/page.tsx
+++ b/digital-cathedral/app/page.tsx
@@ -283,7 +283,7 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="px-4 py-20 md:px-8 md:py-28" aria-labelledby="trust-heading">
+      <section className="bg-gradient-to-b from-[#e4e6ea] to-[#33363d] px-4 py-20 md:px-8 md:py-28" aria-labelledby="trust-heading">
         <div className="mx-auto max-w-7xl">
           <div className="mx-auto max-w-3xl text-center">
             <p className={SECTION_LABEL}>Trust pillars</p>
@@ -291,7 +291,7 @@ export default function HomePage() {
           </div>
           <div className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
             {TRUST_PILLARS.map(([title, desc]) => (
-              <div key={title} className="rounded-[1.5rem] border border-[#decda9] bg-white/80 p-6">
+              <div key={title} className="rounded-[1.5rem] border border-white/60 bg-white p-6 shadow-[0_12px_34px_rgba(0,0,0,0.12)]">
                 <h3 className="font-serif text-2xl text-[#241d15]">{title}</h3>
                 <p className="mt-3 leading-7 text-[#6a5c4b]">{desc}</p>
               </div>
@@ -340,7 +340,7 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section id="protection-path" className="bg-[#211a13] px-4 py-20 text-white md:px-8 md:py-28" aria-labelledby="form-heading">
+      <section id="protection-path" className="bg-[#0F1026] px-4 py-20 text-white md:px-8 md:py-28" aria-labelledby="form-heading">
         <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
           <div className="lg:sticky lg:top-24">
             <p className={SECTION_LABEL}>Protection path</p>


### PR DESCRIPTION
Two section-background tweaks. Homepage-only; form and submission logic untouched.

- **Trust Pillars** — light-grey → dark-grey vertical gradient (`from-[#e4e6ea] to-[#33363d]`). Pillar cards switched to solid white with a soft shadow so they stay crisp as the background darkens; the gold label and dark heading sit on the light upper band and stay readable.
- **Protection Path** — recolored from dark brown to the **header's navy** (`#0F1026`, the `.cathedral-nav` base). White heading, light body text, and the white form card carry over unchanged.

Verification: `tsc --noEmit` clean (exit 0); goggles CONSONANT (0.936), meta-debug clean, shape held steady.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW

---
_Generated by [Claude Code](https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW)_