### PR TITLE
Fix main: resolve codex↔main merge collisions (unbreak the build)

### DIFF
--- a/digital-cathedral/app/components/navbar.tsx
+++ b/digital-cathedral/app/components/navbar.tsx
@@ -38,10 +38,6 @@ const NAV_LINKS = [
   { href: "/#guides", label: "Guides" },
   { href: "/about", label: "About" },
   { href: "/#protection-path", label: "Get Started" },
-  { href: "/#life-events", label: "Life Events" },
-  { href: "/resources", label: "Resources" },
-  { href: "/about", label: "About" },
-  { href: "/#protect-family-form", label: "Contact" },
 ];
 
 const PORTAL_NAV_LINKS = [

--- a/digital-cathedral/app/layout.tsx
+++ b/digital-cathedral/app/layout.tsx
@@ -16,9 +16,6 @@ const SITE_URL = BASE_URL;
 const SITE_TITLE = "Valor Legacies | Life Insurance for Every Chapter of Life";
 const SITE_DESCRIPTION =
   "Valor Legacies helps families explore life insurance options for new babies, new homes, marriage, income protection, retirement, final expenses, veterans, and legacy planning.";
-const SITE_TITLE = "Every New Chapter Deserves Protection | Valor Legacies";
-const SITE_DESCRIPTION =
-  "Valor Legacies helps families protect every chapter of life through life insurance solutions designed around real-life moments. Veteran-founded, family-focused, and independent.";
 
 export const metadata: Metadata = {
   title: {

--- a/digital-cathedral/app/page.tsx
+++ b/digital-cathedral/app/page.tsx
@@ -281,7 +281,7 @@ export default function HomePage() {
             ))}
           </div>
         </div>
-      </header>
+      </section>
 
       <section className="bg-gradient-to-b from-[#e4e6ea] to-[#33363d] px-4 py-20 md:px-8 md:py-28" aria-labelledby="trust-heading">
         <div className="mx-auto max-w-7xl">


### PR DESCRIPTION
## Why
The codex→main merge (PR #257) and the main→codex back-merge resolved conflicts by **keeping both copies** of the changed homepage files instead of choosing one. That left duplicate/invalid code that **fails the build**, which is why the recent `main` production deploy and the `main`→codex build both errored. (Production was unaffected — Vercel never promotes a failed build — so `valorlegacies.com` kept serving the last good version.)

## What was broken
- **`layout.tsx`** — `SITE_TITLE` and `SITE_DESCRIPTION` each declared **twice** (old-main's copy + the redesign's) → duplicate-`const` compile error.
- **`page.tsx`** — the Life Chapters `<section>` closed with `</header>` (leftover from old-main's hero) → `Unexpected token \`main\`` JSX parse error.
- **`navbar.tsx`** — `NAV_LINKS` carried the redesign's 5 links **and** old-main's stale anchors (`/#life-events`, `/#protect-family-form`, a duplicate `About`) that don't exist in the redesign.

## The fix
All three files restored to the **live, promoted redesign** version (commit `1abefc4`) — the exact homepage currently serving `valorlegacies.com`. Every other file on `main` (admin routes, APIs, e2e, oracle toolkit, etc.) is untouched.

This makes `main` = the live redesign and un-breaks the build, so `main` can serve as the single source of truth going forward.

## Verification
- `tsc --noEmit` — clean (exit 0)
- `next build` — **succeeds**, all routes compile
- goggles: all three files CONSONANT, meta-debug clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW

---
_Generated by [Claude Code](https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW)_