### PR TITLE
Homepage: Protection Path — teal section with darker-teal content bubble

### DIFF
--- a/digital-cathedral/app/page.tsx
+++ b/digital-cathedral/app/page.tsx
@@ -340,8 +340,8 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section id="protection-path" className="bg-[#0F1026] px-4 py-20 text-white md:px-8 md:py-28" aria-labelledby="form-heading">
-        <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
+      <section id="protection-path" className="bg-[#00A8A8] px-4 py-20 md:px-8 md:py-28" aria-labelledby="form-heading">
+        <div className="mx-auto grid max-w-7xl gap-10 rounded-[2rem] bg-[#0C4A4A] p-6 text-white shadow-[0_30px_90px_rgba(0,0,0,0.28)] md:p-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
           <div className="lg:sticky lg:top-24">
             <p className={SECTION_LABEL}>Protection path</p>
             <h2 id="form-heading" className="font-serif text-3xl font-light leading-tight text-white md:text-5xl">Find Your Protection Path</h2>


### PR DESCRIPTION
Re-homed onto `main` (supersedes PR #267, which targeted the now-retired codex flow). Single-section change; form and submission logic untouched.

- **Protection Path** section background = the header wordmark teal (`#00A8A8`).
- Content sits in a rounded **darker-teal bubble** (`#0C4A4A`) — the "Our Story" color-field + inset-panel pattern — so the white heading/copy and the white form card stay readable (fixes the low-contrast lettering from putting text directly on the bright teal).
- Only the Protection Path section changes (2 lines).

Verification: `tsc --noEmit` clean (exit 0); goggles CONSONANT, meta-debug clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW

---
_Generated by [Claude Code](https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW)_