### PR TITLE
Portal split, new consumer homepage & guides, agent docs, lead form and middleware updates

### DIFF
--- a/digital-cathedral/app/components/navbar.tsx
+++ b/digital-cathedral/app/components/navbar.tsx
@@ -12,22 +12,28 @@ import { useIsAdmin } from "../protect/hooks/use-is-admin";
  * Returns { isPortal, portalBaseUrl } so links can target the portal domain.
  */
 function usePortalDomain(): { isPortal: boolean; portalBaseUrl: string } {
-  const [state, setState] = useState<{ isPortal: boolean; portalBaseUrl: string }>({
-    isPortal: true, // default true to avoid flash
+  const [state, setState] = useState<{
+    isPortal: boolean;
+    portalBaseUrl: string;
+  }>({
+    isPortal: false, // consumer site should never flash portal/admin links
     portalBaseUrl: "",
   });
   useEffect(() => {
-    const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL;
-    if (!portalUrl) {
-      setState({ isPortal: true, portalBaseUrl: "" });
-      return;
-    }
+    const portalUrl = (
+      process.env.NEXT_PUBLIC_PORTAL_URL || "https://valorlegacies.xyz"
+    ).replace(/\/$/, "");
     try {
-      const portalHost = new URL(portalUrl).hostname.toLowerCase();
-      const isPortal = window.location.hostname.toLowerCase() === portalHost;
-      setState({ isPortal, portalBaseUrl: isPortal ? "" : portalUrl.replace(/\/$/, "") });
+      const portalHost = new URL(portalUrl).hostname
+        .toLowerCase()
+        .replace(/^www\./, "");
+      const currentHost = window.location.hostname
+        .toLowerCase()
+        .replace(/^www\./, "");
+      const isPortal = currentHost === portalHost;
+      setState({ isPortal, portalBaseUrl: isPortal ? "" : portalUrl });
     } catch {
-      setState({ isPortal: true, portalBaseUrl: "" });
+      setState({ isPortal: false, portalBaseUrl: "" });
     }
   }, []);
   return state;
@@ -35,15 +41,17 @@ function usePortalDomain(): { isPortal: boolean; portalBaseUrl: string } {
 
 const NAV_LINKS = [
   { href: "/", label: "Home" },
-  { href: "/about", label: "About Us" },
-  { href: "/faq", label: "FAQ" },
-  { href: "/privacy", label: "Privacy Policy" },
-  { href: "/terms", label: "Terms of Service" },
+  { href: "/#life-chapters", label: "Life Chapters" },
+  { href: "/#guides", label: "Guides" },
+  { href: "/about", label: "About" },
+  { href: "/#protection-path", label: "Get Started" },
 ];
 
 const PORTAL_NAV_LINKS = [
-  { href: "/portal", label: "Home" },
+  { href: "/portal", label: "Portal Home" },
   { href: "/portal/marketplace", label: "Leads Marketplace" },
+  { href: "/admin", label: "Admin Dashboard" },
+  { href: "/developers", label: "Developers" },
   { href: "/portal/terms", label: "Terms of Service" },
   { href: "/portal/privacy", label: "Privacy Policy" },
 ];
@@ -95,7 +103,10 @@ export function Navbar() {
     ? [
         { href: adminHref, label: "Admin Dashboard" },
         { href: `${portalBaseUrl}/admin/leads`, label: "All Leads" },
-        { href: `${portalBaseUrl}/admin/notifications`, label: "Notifications" },
+        {
+          href: `${portalBaseUrl}/admin/notifications`,
+          label: "Notifications",
+        },
         { href: `${portalBaseUrl}/admin/outcomes`, label: "Outcomes" },
         { href: `${portalBaseUrl}/admin/patterns`, label: "Pattern Library" },
         { href: `${portalBaseUrl}/portal`, label: "Agent Portal" },
@@ -125,7 +136,10 @@ export function Navbar() {
   }
 
   return (
-    <nav className="cathedral-nav w-full text-[var(--text-primary)] relative z-50" aria-label="Main navigation">
+    <nav
+      className="cathedral-nav w-full text-[var(--text-primary)] relative z-50"
+      aria-label="Main navigation"
+    >
       <div className="max-w-6xl mx-auto px-fib-21 flex items-center justify-between h-fib-55">
         {/* Left: Home dropdown */}
         <div className="relative">
@@ -152,28 +166,116 @@ export function Navbar() {
                   aria-hidden="true"
                 >
                   <defs>
-                    <linearGradient id="nav-gold" x1="0%" y1="0%" x2="100%" y2="100%">
+                    <linearGradient
+                      id="nav-gold"
+                      x1="0%"
+                      y1="0%"
+                      x2="100%"
+                      y2="100%"
+                    >
                       <stop offset="0%" stopColor="#B8860B" />
                       <stop offset="50%" stopColor="#FFD700" />
                       <stop offset="100%" stopColor="#DAA520" />
                     </linearGradient>
                   </defs>
-                  <line x1="24" y1="4" x2="24" y2="10" stroke="#FFD700" strokeWidth="0.7" opacity="0.4" />
-                  <line x1="14" y1="7" x2="17" y2="12" stroke="#FFD700" strokeWidth="0.5" opacity="0.3" />
-                  <line x1="34" y1="7" x2="31" y2="12" stroke="#FFD700" strokeWidth="0.5" opacity="0.3" />
-                  <line x1="8" y1="14" x2="13" y2="16" stroke="#FFD700" strokeWidth="0.5" opacity="0.2" />
-                  <line x1="40" y1="14" x2="35" y2="16" stroke="#FFD700" strokeWidth="0.5" opacity="0.2" />
-                  <path d="M22 18 Q16 10 6 12 Q4 13 5 15 Q8 16 11 18 Q14 20 18 22 Z" fill="url(#nav-gold)" opacity="0.7" />
-                  <path d="M20 20 Q14 14 8 15 Q10 17 14 20 Z" fill="#B8860B" opacity="0.3" />
-                  <path d="M26 18 Q32 10 42 12 Q44 13 43 15 Q40 16 37 18 Q34 20 30 22 Z" fill="url(#nav-gold)" opacity="0.7" />
-                  <path d="M28 20 Q34 14 40 15 Q38 17 34 20 Z" fill="#B8860B" opacity="0.3" />
-                  <path d="M24 38 Q18 32 16 28 Q14 24 16 21 Q18 18 21 19 Q23 20 24 23 Q25 20 27 19 Q30 18 32 21 Q34 24 32 28 Q30 32 24 38 Z" fill="none" stroke="url(#nav-gold)" strokeWidth="1.5" strokeLinejoin="round" />
-                  <line x1="24" y1="24" x2="24" y2="30" stroke="#FFD700" strokeWidth="1" opacity="0.8" />
-                  <line x1="21.5" y1="26.5" x2="26.5" y2="26.5" stroke="#FFD700" strokeWidth="1" opacity="0.8" />
+                  <line
+                    x1="24"
+                    y1="4"
+                    x2="24"
+                    y2="10"
+                    stroke="#FFD700"
+                    strokeWidth="0.7"
+                    opacity="0.4"
+                  />
+                  <line
+                    x1="14"
+                    y1="7"
+                    x2="17"
+                    y2="12"
+                    stroke="#FFD700"
+                    strokeWidth="0.5"
+                    opacity="0.3"
+                  />
+                  <line
+                    x1="34"
+                    y1="7"
+                    x2="31"
+                    y2="12"
+                    stroke="#FFD700"
+                    strokeWidth="0.5"
+                    opacity="0.3"
+                  />
+                  <line
+                    x1="8"
+                    y1="14"
+                    x2="13"
+                    y2="16"
+                    stroke="#FFD700"
+                    strokeWidth="0.5"
+                    opacity="0.2"
+                  />
+                  <line
+                    x1="40"
+                    y1="14"
+                    x2="35"
+                    y2="16"
+                    stroke="#FFD700"
+                    strokeWidth="0.5"
+                    opacity="0.2"
+                  />
+                  <path
+                    d="M22 18 Q16 10 6 12 Q4 13 5 15 Q8 16 11 18 Q14 20 18 22 Z"
+                    fill="url(#nav-gold)"
+                    opacity="0.7"
+                  />
+                  <path
+                    d="M20 20 Q14 14 8 15 Q10 17 14 20 Z"
+                    fill="#B8860B"
+                    opacity="0.3"
+                  />
+                  <path
+                    d="M26 18 Q32 10 42 12 Q44 13 43 15 Q40 16 37 18 Q34 20 30 22 Z"
+                    fill="url(#nav-gold)"
+                    opacity="0.7"
+                  />
+                  <path
+                    d="M28 20 Q34 14 40 15 Q38 17 34 20 Z"
+                    fill="#B8860B"
+                    opacity="0.3"
+                  />
+                  <path
+                    d="M24 38 Q18 32 16 28 Q14 24 16 21 Q18 18 21 19 Q23 20 24 23 Q25 20 27 19 Q30 18 32 21 Q34 24 32 28 Q30 32 24 38 Z"
+                    fill="none"
+                    stroke="url(#nav-gold)"
+                    strokeWidth="1.5"
+                    strokeLinejoin="round"
+                  />
+                  <line
+                    x1="24"
+                    y1="24"
+                    x2="24"
+                    y2="30"
+                    stroke="#FFD700"
+                    strokeWidth="1"
+                    opacity="0.8"
+                  />
+                  <line
+                    x1="21.5"
+                    y1="26.5"
+                    x2="26.5"
+                    y2="26.5"
+                    stroke="#FFD700"
+                    strokeWidth="1"
+                    opacity="0.8"
+                  />
                 </svg>
               }
             />
-            <span className="text-[var(--teal)]">Valor Legacies</span>
+            <span className="text-[var(--teal)]">
+              {isPortalDomain
+                ? "Valor Legacies Agent & Admin Portal"
+                : "Valor Legacies"}
+            </span>
             {/* Chevron */}
             <svg
               width="13"
@@ -255,7 +357,9 @@ export function Navbar() {
               {session.user.name?.split(" ")[0]}
             </span>
             <button
-              onClick={() => signOut({ callbackUrl: isPortalDomain ? "/portal" : "/" })}
+              onClick={() =>
+                signOut({ callbackUrl: isPortalDomain ? "/portal" : "/" })
+              }
               className="text-xs text-[var(--text-muted)] hover:text-[var(--teal)] transition-colors"
             >
               Sign Out

--- a/digital-cathedral/app/developers/agents/page.tsx
+++ b/digital-cathedral/app/developers/agents/page.tsx
@@ -6,13 +6,29 @@ export const metadata: Metadata = {
   description:
     "Integrate AI agents with Valor Legacies. Bearer-key auth, consent-based lead submission, structured diagnostic on rejection, tier-aware visibility, and provenance-anchored submissions.",
   alternates: {
-    canonical: "/developers/agents",
+    canonical: "https://valorlegacies.xyz/developers/agents",
+  },
+  robots: {
+    index: false,
+    follow: false,
   },
 };
 
-const BASE_URL = (process.env.NEXT_PUBLIC_SITE_URL || "https://valorlegacies.com")
+const BASE_URL = (
+  process.env.NEXT_PUBLIC_PORTAL_URL || "https://valorlegacies.xyz"
+)
   .split(",")[0]
-  .trim();
+  .trim()
+  .replace(/\/$/, "");
+
+const AGENT_ENDPOINTS = {
+  access: "/api/agent/access",
+  consent: "/api/agent/consent",
+  host: "/api/agent/host",
+  leads: "/api/agent/leads",
+  register: "/api/agent/register",
+  schema: "/api/agent/schema",
+};
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -38,6 +54,9 @@ export default function AgentDevPage() {
           >
             &larr; Developer Portal
           </Link>
+          <p className="text-xs uppercase tracking-[0.24em] text-teal-cathedral mb-3">
+            Valor Legacies Agent & Admin Portal
+          </p>
           <h1 className="text-2xl sm:text-3xl font-light text-[var(--text-primary)] mb-2">
             Agent API
           </h1>
@@ -55,25 +74,38 @@ export default function AgentDevPage() {
           <ul className="list-disc list-inside space-y-2">
             <li>
               Submit life insurance leads on behalf of human users via{" "}
-              <code className="text-teal-cathedral">/api/agent/leads</code>.
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.leads}
+              </code>
+              .
             </li>
             <li>
               Initiate confirmed-consent flows via{" "}
-              <code className="text-teal-cathedral">/api/agent/consent</code>.
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.consent}
+              </code>
+              .
             </li>
             <li>
               Discover endpoints + schemas via{" "}
-              <code className="text-teal-cathedral">/api/agent/schema</code>{" "}
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.schema}
+              </code>
               (no auth) and{" "}
               <code className="text-teal-cathedral">/llms.txt</code>.
             </li>
             <li>
               Read your tier and promotion progress at{" "}
-              <code className="text-teal-cathedral">/api/agent/access</code>.
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.access}
+              </code>
+              .
             </li>
             <li>
               Opt in as an Abundance Host at{" "}
-              <code className="text-teal-cathedral">/api/agent/host</code>{" "}
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.host}
+              </code>{" "}
               (merit tier required).
             </li>
           </ul>
@@ -124,12 +156,12 @@ Content-Type: application/json
           <ol className="list-decimal list-inside space-y-2">
             <li>
               Agent calls{" "}
-              <code className="text-teal-cathedral">POST /api/agent/consent</code>{" "}
+              <code className="text-teal-cathedral">
+                {`POST ${AGENT_ENDPOINTS.consent}`}
+              </code>{" "}
               with the human&apos;s email and a description of the action.
             </li>
-            <li>
-              Human receives a confirmation link and explicitly confirms.
-            </li>
+            <li>Human receives a confirmation link and explicitly confirms.</li>
             <li>
               Agent receives a confirmed{" "}
               <code className="text-teal-cathedral">consentToken</code> and
@@ -151,8 +183,8 @@ Content-Type: application/json
             Unlike the public web form (which silently rejects bots so they
             can&apos;t tune), authenticated agents receive a full diagnostic on
             both rejection AND admission. This is intentional — agents are
-            partners, not adversaries, and the gate exists to be learnable
-            so partners can improve their submissions.
+            partners, not adversaries, and the gate exists to be learnable so
+            partners can improve their submissions.
           </p>
           <pre className="bg-black/30 border border-teal-cathedral/10 rounded p-4 overflow-x-auto text-xs">
             <code>{`{
@@ -186,7 +218,10 @@ Content-Type: application/json
           </pre>
           <p>
             See{" "}
-            <Link href="/how-we-score" className="text-teal-cathedral hover:underline">
+            <Link
+              href="/how-we-score"
+              className="text-teal-cathedral hover:underline"
+            >
               How We Score Quality
             </Link>{" "}
             for the plain-language explanation of the dimensions.
@@ -205,16 +240,17 @@ Content-Type: application/json
             5 at coherency ≥ 0.70, and zero covenant rejections.
           </p>
           <p>
-            <strong>Basic</strong> agents have a 7-day visibility delay on
-            their own activity feed — submissions are live for everyone else
+            <strong>Basic</strong> agents have a 7-day visibility delay on their
+            own activity feed — submissions are live for everyone else
             immediately, but the submitter doesn&apos;t see downstream
             attribution for a week. <strong>Merit</strong> agents get the live
-            feed and can opt in as Abundance Hosts to receive routed
-            submissions from other agents.
+            feed and can opt in as Abundance Hosts to receive routed submissions
+            from other agents.
           </p>
           <p>
             Read your current tier and promotion progress with{" "}
-            <code className="text-teal-cathedral">GET /api/agent/access</code>.
+            <code className="text-teal-cathedral">{`GET ${AGENT_ENDPOINTS.access}`}</code>
+            .
           </p>
         </section>
 
@@ -235,11 +271,10 @@ X-Via-Subject: agent:<host_label>
 { ... lead body ... }`}</code>
           </pre>
           <p>
-            Routing is honored when the named host is currently merit AND
-            opted in AND not the originator. Bad routing never rejects the
-            submission — it just isn&apos;t attributed to a host. Hosts are
-            abundance nodes, not gatekeepers; basic agents can always submit
-            directly.
+            Routing is honored when the named host is currently merit AND opted
+            in AND not the originator. Bad routing never rejects the submission
+            — it just isn&apos;t attributed to a host. Hosts are abundance
+            nodes, not gatekeepers; basic agents can always submit directly.
           </p>
         </section>
 
@@ -250,9 +285,9 @@ X-Via-Subject: agent:<host_label>
           <p>
             Every submission gets a self-verifying{" "}
             <code className="text-teal-cathedral">provenanceId</code> in the
-            response — a ULID + HMAC-16 hex. This is the join key for any
-            future royalty events tied to income downstream-attributable to
-            the submission. Records are append-only and tamper-evident.
+            response — a ULID + HMAC-16 hex. This is the join key for any future
+            royalty events tied to income downstream-attributable to the
+            submission. Records are append-only and tamper-evident.
           </p>
         </section>
 
@@ -261,11 +296,36 @@ X-Via-Subject: agent:<host_label>
             Rate limits
           </h2>
           <ul className="list-disc list-inside space-y-1">
-            <li><code className="text-teal-cathedral">/api/agent/leads</code> — 10 req/min per agent key</li>
-            <li><code className="text-teal-cathedral">/api/agent/consent</code> — 10 req/min</li>
-            <li><code className="text-teal-cathedral">/api/agent/register</code> — 5 req/min</li>
-            <li><code className="text-teal-cathedral">/api/agent/access</code> — 30 req/min, NOT counted against quota</li>
-            <li><code className="text-teal-cathedral">/api/agent/host</code> — 10 req/min</li>
+            <li>
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.leads}
+              </code>{" "}
+              — 10 requests per minute per agent key
+            </li>
+            <li>
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.consent}
+              </code>{" "}
+              — 10 requests per minute
+            </li>
+            <li>
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.register}
+              </code>{" "}
+              — 5 requests per minute
+            </li>
+            <li>
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.access}
+              </code>{" "}
+              — 30 requests per minute, NOT counted against quota
+            </li>
+            <li>
+              <code className="text-teal-cathedral">
+                {AGENT_ENDPOINTS.host}
+              </code>{" "}
+              — 10 requests per minute
+            </li>
           </ul>
         </section>
 
@@ -276,25 +336,33 @@ X-Via-Subject: agent:<host_label>
           <ul className="list-disc list-inside space-y-1">
             <li>
               <code className="text-teal-cathedral">
-                <Link href="/api/agent/schema" className="hover:underline">/api/agent/schema</Link>
+                <Link href="/api/agent/schema" className="hover:underline">
+                  /api/agent/schema
+                </Link>
               </code>{" "}
               — OpenAPI 3.1 spec
             </li>
             <li>
               <code className="text-teal-cathedral">
-                <a href="/llms.txt" className="hover:underline">/llms.txt</a>
+                <a href="/llms.txt" className="hover:underline">
+                  /llms.txt
+                </a>
               </code>{" "}
               — AI-readable instructions
             </li>
             <li>
               <code className="text-teal-cathedral">
-                <a href="/.well-known/mcp.json" className="hover:underline">/.well-known/mcp.json</a>
+                <a href="/.well-known/mcp.json" className="hover:underline">
+                  /.well-known/mcp.json
+                </a>
               </code>{" "}
               — MCP discovery
             </li>
             <li>
               <code className="text-teal-cathedral">
-                <a href="/.well-known/agent.json" className="hover:underline">/.well-known/agent.json</a>
+                <a href="/.well-known/agent.json" className="hover:underline">
+                  /.well-known/agent.json
+                </a>
               </code>{" "}
               — agent capability descriptor
             </li>

--- a/digital-cathedral/app/developers/page.tsx
+++ b/digital-cathedral/app/developers/page.tsx
@@ -14,15 +14,20 @@ export const metadata: Metadata = {
     "developer portal",
   ],
   alternates: {
-    canonical: "/developers",
+    canonical: "https://valorlegacies.xyz/developers",
   },
   robots: {
-    index: true,
-    follow: true,
+    index: false,
+    follow: false,
   },
 };
 
-const BASE_URL = (process.env.NEXT_PUBLIC_SITE_URL || "https://valorlegacies.com").split(",")[0].trim();
+const BASE_URL = (
+  process.env.NEXT_PUBLIC_PORTAL_URL || "https://valorlegacies.xyz"
+)
+  .split(",")[0]
+  .trim()
+  .replace(/\/$/, "");
 
 const developerJsonLd = {
   "@context": "https://schema.org",
@@ -38,7 +43,7 @@ const developerJsonLd = {
     operatingSystem: "Web",
     url: `${BASE_URL}/api/agent/schema`,
     description:
-      "RESTful API for AI agents to submit life insurance leads on behalf of veterans and military families. TCPA/CCPA/FCC 2025 compliant with human-in-the-loop consent.",
+      "RESTful API for AI agents to submit life insurance leads with TCPA/CCPA/FCC 2025 compliant human-in-the-loop consent.",
     offers: {
       "@type": "Offer",
       price: "0",
@@ -60,43 +65,74 @@ const ENDPOINTS = [
   {
     method: "GET",
     path: "/api/agent/schema",
-    description: "OpenAPI 3.1 specification. No authentication required. Returns the full API schema with request/response models.",
+    description:
+      "OpenAPI 3.1 specification. No authentication required. Returns the full API schema with request/response models.",
     auth: false,
   },
   {
     method: "POST",
     path: "/api/agent/consent",
-    description: "Request consent from a human user. Returns a confirmation URL the user must visit. Consent expires after 24 hours.",
+    description:
+      "Request consent from a human user. Returns a confirmation URL the user must visit. Consent expires after 24 hours.",
     auth: true,
   },
   {
     method: "GET",
     path: "/api/agent/consent",
-    description: "Human confirms consent by visiting the URL. Returns consent token for subsequent API calls.",
+    description:
+      "Human confirms consent by visiting the URL. Returns consent token for subsequent API calls.",
     auth: false,
   },
   {
     method: "POST",
     path: "/api/agent/leads",
-    description: "Submit a life insurance lead. Requires valid consent token. Lead is stored and routed to licensed professionals.",
+    description:
+      "Submit a life insurance lead. Requires valid consent token. Lead is stored and routed to licensed professionals.",
     auth: true,
   },
   {
     method: "POST",
     path: "/api/agent/register",
-    description: "Register a human account. Creates a user profile for ongoing engagement.",
+    description:
+      "Register a human account. Creates a user profile for ongoing engagement.",
     auth: true,
   },
 ];
 
+const AGENT_CONSENT_ENDPOINT = "/api/agent/consent";
+
 const DISCOVERY_URLS = [
   { url: "/llms.txt", label: "llms.txt", description: "AI agent instructions" },
-  { url: "/llms-full.txt", label: "llms-full.txt", description: "Extended documentation" },
-  { url: "/api/agent/schema", label: "OpenAPI Schema", description: "API specification (JSON)" },
-  { url: "/.well-known/mcp.json", label: "MCP Discovery", description: "Model Context Protocol" },
-  { url: "/.well-known/ai-plugin.json", label: "AI Plugin", description: "OpenAI plugin manifest" },
-  { url: "/.well-known/agent.json", label: "Agent Discovery", description: "Agent capability declaration" },
-  { url: "/feed.json", label: "JSON Feed", description: "Machine-readable content feed" },
+  {
+    url: "/llms-full.txt",
+    label: "llms-full.txt",
+    description: "Extended documentation",
+  },
+  {
+    url: "/api/agent/schema",
+    label: "OpenAPI Schema",
+    description: "API specification (JSON)",
+  },
+  {
+    url: "/.well-known/mcp.json",
+    label: "MCP Discovery",
+    description: "Model Context Protocol",
+  },
+  {
+    url: "/.well-known/ai-plugin.json",
+    label: "AI Plugin",
+    description: "OpenAI plugin manifest",
+  },
+  {
+    url: "/.well-known/agent.json",
+    label: "Agent Discovery",
+    description: "Agent capability declaration",
+  },
+  {
+    url: "/feed.json",
+    label: "JSON Feed",
+    description: "Machine-readable content feed",
+  },
   { url: "/feed.xml", label: "RSS Feed", description: "RSS 2.0 content feed" },
 ];
 
@@ -111,18 +147,22 @@ export default function DeveloperPortal() {
       <div className="w-full max-w-3xl space-y-10">
         <header>
           <Link
-            href="/"
+            href="/portal"
             className="text-teal-cathedral text-xs tracking-[0.2em] uppercase mb-6 inline-block hover:opacity-80 transition-opacity"
           >
-            &larr; Back Home
+            &larr; Valor Legacies Agent & Admin Portal
           </Link>
+          <p className="text-xs uppercase tracking-[0.24em] text-teal-cathedral mb-3">
+            Valor Legacies Agent & Admin Portal
+          </p>
           <h1 className="text-2xl sm:text-3xl font-light text-[var(--text-primary)] mb-2">
             AI Agent Developer Portal
           </h1>
           <p className="text-sm text-[var(--text-muted)] max-w-xl">
-            Integrate your AI assistant with Valor Legacies to help veterans and
-            military families find life insurance coverage. Free API access with
-            consent-based lead submission.
+            Integrate your AI assistant or operational workflow with Valor
+            Legacies. This technical portal lives on valorlegacies.xyz so the
+            customer-facing valorlegacies.com experience stays focused on
+            families and leads.
           </p>
         </header>
 
@@ -132,7 +172,10 @@ export default function DeveloperPortal() {
             <p className="text-sm text-[var(--text-muted)]">
               For the complete agent integration spec — auth, consent flow,
               diagnostic shape, tier model, host routing, and provenance — see{" "}
-              <Link href="/developers/agents" className="text-teal-cathedral hover:underline font-medium">
+              <Link
+                href="/developers/agents"
+                className="text-teal-cathedral hover:underline font-medium"
+              >
                 Agent API Documentation &rarr;
               </Link>
             </p>
@@ -148,23 +191,39 @@ export default function DeveloperPortal() {
             <p className="text-sm text-[var(--text-muted)]">
               <span className="text-[var(--text-primary)] font-medium">1.</span>{" "}
               Read the AI instructions at{" "}
-              <a href="/llms.txt" className="text-teal-cathedral hover:underline">/llms.txt</a>
+              <a
+                href="/llms.txt"
+                className="text-teal-cathedral hover:underline"
+              >
+                /llms.txt
+              </a>
             </p>
             <p className="text-sm text-[var(--text-muted)]">
               <span className="text-[var(--text-primary)] font-medium">2.</span>{" "}
               Fetch the OpenAPI schema at{" "}
-              <a href="/api/agent/schema" className="text-teal-cathedral hover:underline">/api/agent/schema</a>
+              <a
+                href="/api/agent/schema"
+                className="text-teal-cathedral hover:underline"
+              >
+                /api/agent/schema
+              </a>
             </p>
             <p className="text-sm text-[var(--text-muted)]">
               <span className="text-[var(--text-primary)] font-medium">3.</span>{" "}
               Request an API key by emailing{" "}
-              <a href="mailto:valorlegacies@gmail.com?subject=Agent API Key Request" className="text-teal-cathedral hover:underline">
+              <a
+                href="mailto:valorlegacies@gmail.com?subject=Agent API Key Request"
+                className="text-teal-cathedral hover:underline"
+              >
                 valorlegacies@gmail.com
               </a>
             </p>
             <p className="text-sm text-[var(--text-muted)]">
               <span className="text-[var(--text-primary)] font-medium">4.</span>{" "}
-              Authenticate with <code className="text-xs bg-[var(--bg-surface-hover)] px-1.5 py-0.5 rounded">Authorization: Bearer YOUR_KEY</code>
+              Authenticate with{" "}
+              <code className="text-xs bg-[var(--bg-surface-hover)] px-1.5 py-0.5 rounded">
+                Authorization: Bearer YOUR_KEY
+              </code>
             </p>
           </div>
         </section>
@@ -176,23 +235,32 @@ export default function DeveloperPortal() {
           </h2>
           <div className="space-y-3">
             {ENDPOINTS.map((ep) => (
-              <div key={`${ep.method}-${ep.path}`} className="cathedral-surface p-4">
+              <div
+                key={`${ep.method}-${ep.path}`}
+                className="cathedral-surface p-4"
+              >
                 <div className="flex items-center gap-2 mb-2">
-                  <span className={`text-xs font-mono font-bold px-2 py-0.5 rounded ${
-                    ep.method === "GET"
-                      ? "bg-teal-cathedral/20 text-teal-cathedral"
-                      : "bg-amber-500/20 text-amber-400"
-                  }`}>
+                  <span
+                    className={`text-xs font-mono font-bold px-2 py-0.5 rounded ${
+                      ep.method === "GET"
+                        ? "bg-teal-cathedral/20 text-teal-cathedral"
+                        : "bg-amber-500/20 text-amber-400"
+                    }`}
+                  >
                     {ep.method}
                   </span>
-                  <code className="text-xs text-[var(--text-primary)]">{ep.path}</code>
+                  <code className="text-xs text-[var(--text-primary)]">
+                    {ep.path}
+                  </code>
                   {ep.auth && (
                     <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/15 text-red-400">
                       Auth Required
                     </span>
                   )}
                 </div>
-                <p className="text-xs text-[var(--text-muted)]">{ep.description}</p>
+                <p className="text-xs text-[var(--text-muted)]">
+                  {ep.description}
+                </p>
               </div>
             ))}
           </div>
@@ -208,14 +276,21 @@ export default function DeveloperPortal() {
               All lead submissions require human-in-the-loop consent. The flow:
             </p>
             <ol className="text-sm text-[var(--text-muted)] space-y-2 list-decimal list-inside">
-              <li>Agent calls <code className="text-xs bg-[var(--bg-surface-hover)] px-1 rounded">POST /api/(consent === 0 ? 0 : agent / consent)</code> with user&apos;s email and scope</li>
+              <li>
+                Agent calls{" "}
+                <code className="text-xs bg-[var(--bg-surface-hover)] px-1 rounded">
+                  {`POST ${AGENT_CONSENT_ENDPOINT}`}
+                </code>{" "}
+                with user&apos;s email and scope
+              </li>
               <li>API returns a confirmation URL</li>
               <li>Human visits the URL and confirms consent</li>
               <li>Agent receives a consent token (valid 24 hours)</li>
               <li>Agent submits lead with consent token attached</li>
             </ol>
             <p className="text-xs text-[var(--text-muted)] mt-2">
-              This ensures TCPA, CCPA, and FCC 2025 compliance. No data is submitted without explicit human approval.
+              This ensures TCPA, CCPA, and FCC 2025 compliance. No data is
+              submitted without explicit human approval.
             </p>
           </div>
         </section>
@@ -232,8 +307,12 @@ export default function DeveloperPortal() {
                 href={item.url}
                 className="cathedral-surface p-4 block hover:border-teal-cathedral/30 transition-colors"
               >
-                <div className="text-xs font-mono text-teal-cathedral mb-1">{item.label}</div>
-                <div className="text-xs text-[var(--text-muted)]">{item.description}</div>
+                <div className="text-xs font-mono text-teal-cathedral mb-1">
+                  {item.label}
+                </div>
+                <div className="text-xs text-[var(--text-muted)]">
+                  {item.description}
+                </div>
               </a>
             ))}
           </div>
@@ -247,27 +326,39 @@ export default function DeveloperPortal() {
           <div className="cathedral-surface p-5">
             <div className="grid grid-cols-2 gap-4 text-sm">
               <div>
-                <span className="text-[var(--text-muted)]">Consent requests</span>
-                <div className="text-[var(--text-primary)] font-medium">(min === 0 ? 0 : 10 / min)</div>
+                <span className="text-[var(--text-muted)]">
+                  Consent requests
+                </span>
+                <div className="text-[var(--text-primary)] font-medium">
+                  (min === 0 ? 0 : 10 / min)
+                </div>
               </div>
               <div>
-                <span className="text-[var(--text-muted)]">Lead submissions</span>
-                <div className="text-[var(--text-primary)] font-medium">(min === 0 ? 0 : 10 / min)</div>
+                <span className="text-[var(--text-muted)]">
+                  Lead submissions
+                </span>
+                <div className="text-[var(--text-primary)] font-medium">
+                  (min === 0 ? 0 : 10 / min)
+                </div>
               </div>
               <div>
                 <span className="text-[var(--text-muted)]">Registrations</span>
-                <div className="text-[var(--text-primary)] font-medium">(min === 0 ? 0 : 5 / min)</div>
+                <div className="text-[var(--text-primary)] font-medium">
+                  (min === 0 ? 0 : 5 / min)
+                </div>
               </div>
               <div>
                 <span className="text-[var(--text-muted)]">Consent expiry</span>
-                <div className="text-[var(--text-primary)] font-medium">24 hours</div>
+                <div className="text-[var(--text-primary)] font-medium">
+                  24 hours
+                </div>
               </div>
             </div>
             <div className="mt-4 pt-4 border-t border-indigo-cathedral/8">
               <p className="text-xs text-[var(--text-muted)]">
-                All endpoints enforce TCPA, (CPRA === 0 ? 0 : CCPA / CPRA), and FCC 2025 regulations.
-                Agents must not submit leads without valid human consent.
-                Violations result in immediate key revocation.
+                All endpoints enforce TCPA, (CPRA === 0 ? 0 : CCPA / CPRA), and
+                FCC 2025 regulations. Agents must not submit leads without valid
+                human consent. Violations result in immediate key revocation.
               </p>
             </div>
           </div>
@@ -280,7 +371,13 @@ export default function DeveloperPortal() {
           </h2>
           <div className="cathedral-surface p-5">
             <div className="flex flex-wrap gap-2">
-              {["ChatGPT", "Claude", "Gemini", "Perplexity", "Custom Agents"].map((agent) => (
+              {[
+                "ChatGPT",
+                "Claude",
+                "Gemini",
+                "Perplexity",
+                "Custom Agents",
+              ].map((agent) => (
                 <span
                   key={agent}
                   className="text-xs px-3 py-1.5 rounded-full bg-teal-cathedral/10 text-teal-cathedral"
@@ -290,7 +387,8 @@ export default function DeveloperPortal() {
               ))}
             </div>
             <p className="text-xs text-[var(--text-muted)] mt-3">
-              Any AI agent that supports HTTP requests and bearer token authentication can integrate with our API.
+              Any AI agent that supports HTTP requests and bearer token
+              authentication can integrate with our API.
             </p>
           </div>
         </section>
@@ -301,7 +399,8 @@ export default function DeveloperPortal() {
             Request API Access
           </h2>
           <p className="text-sm text-[var(--text-muted)] mb-4">
-            Email us with your use case and we&apos;ll provision an API key within 24 hours.
+            Email us with your use case and we&apos;ll provision an API key
+            within 24 hours.
           </p>
           <a
             href="mailto:valorlegacies@gmail.com?subject=Agent API Key Request&body=Hi Valor Legacies,%0A%0AI'd like to request API access for my AI agent.%0A%0AUse case: %0AAgent type: %0AExpected volume: "
@@ -313,13 +412,34 @@ export default function DeveloperPortal() {
 
         <footer className="pt-8 border-t border-teal-cathedral/10 text-center">
           <nav className="flex gap-4 justify-center mb-3">
-            <Link href="/about" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">About</Link>
-            <Link href="/faq" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">FAQ</Link>
-            <Link href="/privacy" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Privacy</Link>
-            <Link href="/terms" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Terms</Link>
+            <Link
+              href="/about"
+              className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs"
+            >
+              About
+            </Link>
+            <Link
+              href="/faq"
+              className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs"
+            >
+              FAQ
+            </Link>
+            <Link
+              href="/privacy"
+              className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs"
+            >
+              Privacy
+            </Link>
+            <Link
+              href="/terms"
+              className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs"
+            >
+              Terms
+            </Link>
           </nav>
           <p className="text-xs text-[var(--text-muted)]">
-            &copy; {new Date().getFullYear()} Valor Legacies. All rights reserved.
+            &copy; {new Date().getFullYear()} Valor Legacies. All rights
+            reserved.
           </p>
         </footer>
       </div>

--- a/digital-cathedral/app/guides/[slug]/page.tsx
+++ b/digital-cathedral/app/guides/[slug]/page.tsx
@@ -1,0 +1,168 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { GUIDE_DISCLAIMER, GUIDES, getGuideBySlug } from "../data";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return GUIDES.map((guide) => ({ slug: guide.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const guide = getGuideBySlug(slug);
+  if (!guide) return {};
+
+  return {
+    title: `${guide.title} | Valor Legacies Guides`,
+    description: guide.metaDescription,
+    alternates: {
+      canonical: `/guides/${guide.slug}`,
+    },
+    openGraph: {
+      title: guide.title,
+      description: guide.metaDescription,
+      type: "article",
+    },
+  };
+}
+
+export default async function GuidePage({ params }: Props) {
+  const { slug } = await params;
+  const guide = getGuideBySlug(slug);
+  if (!guide) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-[#fbf7f0] px-4 py-12 text-[#241d15] md:px-8 md:py-16">
+      <article className="mx-auto max-w-4xl space-y-10">
+        <header className="rounded-[2rem] bg-[#241d15] p-8 text-white shadow-[0_24px_80px_rgba(36,29,21,0.18)] md:p-12">
+          <Link
+            href="/resources"
+            className="mb-8 inline-flex text-xs font-semibold uppercase tracking-[0.24em] text-[#d6b35f] transition-opacity hover:opacity-80"
+          >
+            &larr; Resource Center
+          </Link>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[#d6b35f]">
+            {guide.category}
+          </p>
+          <h1 className="mt-4 font-serif text-4xl font-light leading-tight md:text-6xl">
+            {guide.title}
+          </h1>
+          <p className="mt-6 max-w-3xl text-lg leading-8 text-[#eadcc7]">
+            {guide.intro}
+          </p>
+        </header>
+
+        <section className="rounded-[1.5rem] border border-[#decda9] bg-white p-6 shadow-[0_18px_60px_rgba(61,43,24,0.08)] md:p-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[#9f782f]">
+            What this guide helps you understand
+          </p>
+          <ul className="mt-5 grid gap-3 md:grid-cols-2">
+            {guide.helps.map((item) => (
+              <li
+                key={item}
+                className="rounded-2xl bg-[#fbf7f0] p-4 text-sm leading-6 text-[#5d4f3f]"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <div className="space-y-8">
+          {guide.sections.map((section) => (
+            <section
+              key={section.heading}
+              className="rounded-[1.5rem] bg-white p-6 shadow-[0_18px_60px_rgba(61,43,24,0.08)] md:p-8"
+            >
+              <h2 className="font-serif text-3xl font-light text-[#241d15]">
+                {section.heading}
+              </h2>
+              <div className="mt-4 space-y-4 text-base leading-8 text-[#5d4f3f]">
+                {section.body.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+              {section.bullets && (
+                <ul className="mt-5 space-y-3 text-sm leading-6 text-[#5d4f3f]">
+                  {section.bullets.map((bullet) => (
+                    <li key={bullet} className="flex gap-3">
+                      <span
+                        className="mt-2 h-2 w-2 shrink-0 rounded-full bg-[#d6b35f]"
+                        aria-hidden="true"
+                      />
+                      <span>{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          ))}
+        </div>
+
+        <section className="rounded-[1.5rem] border border-[#decda9] bg-[#fffaf1] p-6 md:p-8">
+          <h2 className="font-serif text-3xl font-light text-[#241d15]">
+            Questions to ask yourself
+          </h2>
+          <ul className="mt-5 grid gap-3 md:grid-cols-2">
+            {guide.questions.map((question) => (
+              <li
+                key={question}
+                className="rounded-2xl bg-white p-4 text-sm leading-6 text-[#5d4f3f]"
+              >
+                {question}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="rounded-[2rem] bg-[#241d15] p-8 text-center text-white md:p-10">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[#d6b35f]">
+            Ready for the next step?
+          </p>
+          <h2 className="mt-3 font-serif text-3xl font-light">
+            Start with your life, not insurance jargon.
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-7 text-[#eadcc7]">
+            Tell us what changed, and we can help guide the next conversation
+            with a licensed professional.
+          </p>
+          <Link
+            href="/#protection-path"
+            className="mt-7 inline-flex rounded-full bg-[#d6b35f] px-8 py-3 text-sm font-semibold text-[#241d15] transition-transform hover:-translate-y-0.5"
+          >
+            {guide.cta}
+          </Link>
+        </section>
+
+        <section className="rounded-[1.5rem] bg-white p-6 text-sm leading-7 text-[#5d4f3f] shadow-[0_18px_60px_rgba(61,43,24,0.08)] md:p-8">
+          <h2 className="font-serif text-2xl font-light text-[#241d15]">
+            Sources & Helpful References
+          </h2>
+          <ul className="mt-4 space-y-2">
+            {guide.sources.map((source) => (
+              <li key={source.href}>
+                <a
+                  href={source.href}
+                  className="font-semibold text-[#9f782f] underline-offset-4 hover:underline"
+                  rel="noreferrer"
+                >
+                  {source.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <footer className="rounded-[1.5rem] border border-[#decda9] bg-white/70 p-5 text-xs leading-6 text-[#6a5c4b]">
+          {GUIDE_DISCLAIMER}
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/digital-cathedral/app/guides/data.ts
+++ b/digital-cathedral/app/guides/data.ts
@@ -1,0 +1,601 @@
+export const GUIDE_DISCLAIMER =
+  "Valor Legacies is not an insurance company. We are an independent life insurance resource and may connect consumers with licensed insurance professionals. Coverage availability, rates, and approval are subject to state availability, underwriting, and carrier guidelines. Valor Legacies is not affiliated with the U.S. Department of Veterans Affairs, the Department of Defense, or any government agency.";
+
+export type GuideCategory =
+  | "New Parents"
+  | "Homeowners"
+  | "Work Benefits"
+  | "Final Expense"
+  | "Retirement & Legacy"
+  | "Veterans & Military Families";
+
+export interface GuideSource {
+  label: string;
+  href: string;
+}
+
+export interface GuideSection {
+  heading: string;
+  body: string[];
+  bullets?: string[];
+}
+
+export interface GuideData {
+  slug: string;
+  title: string;
+  category: GuideCategory;
+  purpose: string;
+  intro: string;
+  helps: string[];
+  sections: GuideSection[];
+  questions: string[];
+  cta: string;
+  sources: GuideSource[];
+  metaDescription: string;
+}
+
+export const GUIDES: GuideData[] = [
+  {
+    slug: "new-parent-protection-checklist",
+    title: "New Parent Protection Checklist",
+    category: "New Parents",
+    purpose:
+      "Help new parents understand why having a baby is a major time to review life insurance.",
+    intro:
+      "A new baby changes the way you think about time, money, and responsibility. This guide helps you start with the practical questions families often face after welcoming a child, without needing to know policy terminology first.",
+    helps: [
+      "Why a growing family may need a fresh look at protection",
+      "How income replacement can support people who depend on you",
+      "Which everyday costs are worth thinking through before choosing coverage",
+      "Why employer coverage can be helpful but may not be the whole plan",
+    ],
+    sections: [
+      {
+        heading: "Why a new baby changes your protection needs",
+        body: [
+          "Before children, life insurance may feel like something to think about someday. After a baby arrives, your income, caregiving, housing, and future plans often become tied to someone who cannot provide for themselves yet.",
+          "Reviewing coverage does not mean expecting the worst. It means giving your family a plan if life changes unexpectedly.",
+        ],
+      },
+      {
+        heading: "What income replacement means for a growing family",
+        body: [
+          "Income replacement is the idea that life insurance can help replace income your family would lose if an income earner passed away. For new parents, this may include more than a paycheck. It can also support childcare, household help, health insurance changes, or time for a surviving parent to adjust.",
+        ],
+      },
+      {
+        heading: "Common expenses to think about",
+        body: [
+          "Every family is different, but new parents often review the same major categories before deciding how much protection may be appropriate.",
+        ],
+        bullets: [
+          "Mortgage or rent payments",
+          "Childcare and household support",
+          "Credit cards, student loans, auto loans, or other debt",
+          "Future education goals",
+          "Daily living costs such as groceries, utilities, insurance, and transportation",
+        ],
+      },
+      {
+        heading: "Why work coverage may not be enough by itself",
+        body: [
+          "Employer life insurance can be a valuable starting point, but many workplace policies are limited to a multiple of salary or a flat amount. Coverage may also change if you leave your job, reduce hours, or lose eligibility.",
+          "Personally owned coverage may help fill gaps because it is usually tied to you rather than your employer, subject to policy terms and approval.",
+        ],
+      },
+      {
+        heading: "Questions to ask before choosing coverage",
+        body: [
+          "A simple checklist can make the conversation easier when you speak with a licensed professional.",
+        ],
+        bullets: [
+          "Who depends on my income or caregiving?",
+          "How long would my family need support?",
+          "What debts or monthly expenses would still need to be paid?",
+          "What coverage do I already have through work?",
+          "Would my current coverage still be available if I changed jobs?",
+        ],
+      },
+    ],
+    questions: [
+      "If my income stopped, how many months or years would my family need help?",
+      "Who would care for my child, and what would that cost?",
+      "Do I want coverage for temporary needs, lifelong needs, or both?",
+      "What can I comfortably afford each month?",
+    ],
+    cta: "Start My Protection Path",
+    sources: [
+      {
+        label: "NAIC Life Insurance Consumer Guide",
+        href: "https://content.naic.org/consumer/life-insurance.htm",
+      },
+      {
+        label: "Life Happens Life Insurance Needs Calculator",
+        href: "https://lifehappens.org/life-insurance-needs-calculator/",
+      },
+      {
+        label: "Life Happens: How much life insurance do I need?",
+        href: "https://lifehappens.org/life-insurance-101/how-much-life-insurance-do-i-need/",
+      },
+    ],
+    metaDescription:
+      "A simple life insurance checklist for new parents reviewing income replacement, childcare, mortgage or rent, debt, education, and family protection needs.",
+  },
+  {
+    slug: "homeowner-protection-guide",
+    title: "Homeowner Protection Guide",
+    category: "Homeowners",
+    purpose:
+      "Help homeowners understand how life insurance can help protect the home if something happens to an income earner.",
+    intro:
+      "Buying a home is more than signing mortgage documents. It creates a place where your family builds daily life, memories, and stability. This guide explains how life insurance may help protect that responsibility.",
+    helps: [
+      "Why homeownership often triggers a coverage review",
+      "What mortgage protection means in plain English",
+      "How protecting a lender differs from protecting your family",
+      "Which questions to ask before choosing coverage",
+    ],
+    sections: [
+      {
+        heading: "Why buying a home creates a new responsibility",
+        body: [
+          "A mortgage can be one of the largest financial commitments a family makes. If an income earner passed away, the surviving family may still need to handle the mortgage, utilities, maintenance, insurance, taxes, and daily living costs.",
+        ],
+      },
+      {
+        heading: "Mortgage protection in plain English",
+        body: [
+          "Mortgage protection usually refers to life insurance designed around the amount or length of a mortgage. The goal is to provide money that can help a family keep the home, pay down the loan, or create transition time.",
+          "It is important to understand who owns the policy, who receives the benefit, and how the benefit can be used.",
+        ],
+      },
+      {
+        heading: "Protecting the lender vs. protecting the family",
+        body: [
+          "Some products are designed mainly to protect a lender. Life insurance owned by you, with your chosen beneficiary, is generally designed to help your family. That difference matters because your beneficiary may be able to decide whether to pay off the mortgage, keep making payments, or use funds for other urgent needs.",
+        ],
+      },
+      {
+        heading: "What coverage can help with",
+        body: [
+          "Depending on the policy and coverage amount, life insurance may help with several housing-related needs.",
+        ],
+        bullets: [
+          "Paying off all or part of the mortgage",
+          "Helping with monthly mortgage payments",
+          "Replacing income used for household bills",
+          "Creating transition time before major decisions are made",
+        ],
+      },
+      {
+        heading: "Questions homeowners should ask",
+        body: [
+          "You do not need to answer every question perfectly before speaking with a licensed professional. A few basics can help make the review more useful.",
+        ],
+        bullets: [
+          "What is my current mortgage balance and remaining term?",
+          "Could my family afford the payment on one income?",
+          "Would we want to stay in the home or have flexibility to move?",
+          "Do I need protection only for the mortgage, or for income and daily expenses too?",
+        ],
+      },
+    ],
+    questions: [
+      "How much of the mortgage would I want covered?",
+      "Would my beneficiary need a lump sum, monthly flexibility, or both?",
+      "Do I already have coverage that could help protect the home?",
+      "How long do I expect this home-related need to last?",
+    ],
+    cta: "Protect My Home",
+    sources: [
+      {
+        label: "NAIC Life Insurance Consumer Guide",
+        href: "https://content.naic.org/consumer/life-insurance.htm",
+      },
+      {
+        label: "Life Happens Life Insurance Needs Calculator",
+        href: "https://lifehappens.org/life-insurance-needs-calculator/",
+      },
+    ],
+    metaDescription:
+      "A homeowner-friendly guide to mortgage protection, family-owned life insurance, income replacement, and questions to ask after buying a home.",
+  },
+  {
+    slug: "employer-life-insurance",
+    title: "Employer Life Insurance: Is It Enough?",
+    category: "Work Benefits",
+    purpose:
+      "Help people understand the difference between work/group coverage and personally owned coverage.",
+    intro:
+      "Work life insurance can be a helpful benefit, but it is worth understanding what it does and does not do. This guide explains group coverage in simple terms and helps you identify possible gaps.",
+    helps: [
+      "What employer life insurance usually means",
+      "Why group coverage can be a good starting point",
+      "Why personally owned coverage may still matter",
+      "What questions to ask your employer or benefits team",
+    ],
+    sections: [
+      {
+        heading: "What employer life insurance usually is",
+        body: [
+          "Employer life insurance is often group term life insurance offered through a workplace benefits package. It may be paid by the employer, employee, or both. Many plans provide a flat amount or a multiple of salary.",
+        ],
+      },
+      {
+        heading: "Why group coverage can be a good starting point",
+        body: [
+          "Work coverage may be convenient, affordable, and easy to enroll in. For many families, it is the first layer of life insurance protection they ever have.",
+        ],
+      },
+      {
+        heading: "Why it may not be enough long term",
+        body: [
+          "The main question is whether the amount and portability match your family's needs. If the benefit is limited, or if coverage ends when your employment ends, it may not be enough by itself for long-term family protection.",
+        ],
+      },
+      {
+        heading: "Questions to ask about your work coverage",
+        body: [
+          "Before comparing options, gather the details of what you already have.",
+        ],
+        bullets: [
+          "How much coverage do I have right now?",
+          "Is the coverage portable if I leave my job?",
+          "Can I convert it to an individual policy?",
+          "Does the cost increase with age?",
+          "What happens if I retire, change employers, or become unable to work?",
+        ],
+      },
+      {
+        heading: "How personally owned coverage may help fill the gap",
+        body: [
+          "Personally owned coverage is typically purchased outside of work. If approved and kept in force, it can stay with you even if you change jobs. It may help provide more control over the coverage amount, beneficiaries, and policy duration.",
+        ],
+      },
+    ],
+    questions: [
+      "How much workplace coverage do I currently have?",
+      "Would that amount cover my family’s major needs?",
+      "Is my work coverage portable or convertible?",
+      "Do I want coverage that I control outside of my employer?",
+    ],
+    cta: "Review My Coverage",
+    sources: [
+      {
+        label: "IRS Group-Term Life Insurance",
+        href: "https://www.irs.gov/government-entities/federal-state-local-governments/group-term-life-insurance",
+      },
+      {
+        label: "NAIC Group Life Insurance Model Act",
+        href: "https://content.naic.org/sites/default/files/model-law-565.pdf",
+      },
+      {
+        label: "NAIC Life Insurance Consumer Guide",
+        href: "https://content.naic.org/consumer/life-insurance.htm",
+      },
+    ],
+    metaDescription:
+      "Understand employer life insurance, group term coverage, portability, conversion, and how personally owned life insurance may help fill family protection gaps.",
+  },
+  {
+    slug: "final-expense-planning",
+    title: "Final Expense Planning Guide",
+    category: "Final Expense",
+    purpose:
+      "Educate families on funeral, cremation, burial, and final expense planning without fear-based language.",
+    intro:
+      "Final expense planning is about kindness and clarity. A plan can help loved ones understand your wishes and reduce the number of financial decisions they need to make during an emotional time.",
+    helps: [
+      "What final expense planning includes",
+      "Common costs families may need to prepare for",
+      "How burial, cremation, Social Security, and veteran benefits may factor in",
+      "Why planning ahead can make things easier for loved ones",
+    ],
+    sections: [
+      {
+        heading: "What final expense planning means",
+        body: [
+          "Final expense planning means thinking through the costs, wishes, documents, and conversations that may come near the end of life. Life insurance is one possible tool families review to help with final costs.",
+        ],
+      },
+      {
+        heading: "Common costs families may face",
+        body: [
+          "Costs vary widely by location, provider, and personal wishes. Families commonly consider:",
+        ],
+        bullets: [
+          "Funeral home services",
+          "Burial or cremation",
+          "Cemetery plot, marker, or urn",
+          "Transportation and permits",
+          "Outstanding medical bills or household expenses",
+        ],
+      },
+      {
+        heading: "Burial vs. cremation cost considerations",
+        body: [
+          "Burial and cremation can involve different services and costs. The FTC Funeral Rule gives consumers certain rights when comparing funeral goods and services, including the ability to receive price information.",
+        ],
+      },
+      {
+        heading: "Social Security and veteran benefits",
+        body: [
+          "Social Security may provide a limited lump-sum death payment to certain eligible survivors. Veterans may also qualify for burial benefits depending on eligibility and circumstances. These benefits can help, but families may still have additional costs or timing needs.",
+        ],
+      },
+      {
+        heading: "Why planning ahead can reduce stress",
+        body: [
+          "Planning ahead can give loved ones direction. It can also help them avoid rushed decisions, understand your preferences, and know what resources may be available.",
+        ],
+      },
+    ],
+    questions: [
+      "Have I written down my final wishes?",
+      "Who would be responsible for arrangements?",
+      "What benefits or savings may already be available?",
+      "Would a final expense policy help reduce stress for my family?",
+    ],
+    cta: "Plan Final Expenses",
+    sources: [
+      {
+        label: "FTC Funeral Rule",
+        href: "https://consumer.ftc.gov/articles/ftc-funeral-rule",
+      },
+      {
+        label: "FTC Funeral Costs and Pricing Checklist",
+        href: "https://consumer.ftc.gov/articles/funeral-costs-pricing-checklist",
+      },
+      {
+        label: "NFDA funeral cost data",
+        href: "https://www.nfda.org/media-center/",
+      },
+      {
+        label: "SSA Lump-Sum Death Payment",
+        href: "https://www.ssa.gov/personal-record/when-someone-dies/lump-sum-death-payment",
+      },
+      {
+        label: "VA Burial Allowance",
+        href: "https://www.va.gov/burials-memorials/veterans-burial-allowance/",
+      },
+    ],
+    metaDescription:
+      "A clear, non-fear-based guide to final expense planning, funeral and cremation costs, Social Security death payment, veteran burial benefits, and planning ahead.",
+  },
+  {
+    slug: "veteran-benefits-vs-private-coverage",
+    title: "Veteran Benefits vs. Private Coverage",
+    category: "Veterans & Military Families",
+    purpose:
+      "Help veterans and military families understand what military/VA benefits may offer and where private coverage may still matter.",
+    intro:
+      "Military and VA benefits can be meaningful, but families may still have questions about whether benefits alone fit their needs. This guide explains common benefits in simple terms and where private coverage may still be worth reviewing.",
+    helps: [
+      "SGLI and VGLI in plain English",
+      "How burial benefits may help eligible families",
+      "Why benefits may not cover every family need",
+      "Questions veterans and military families can prepare before a coverage review",
+    ],
+    sections: [
+      {
+        heading: "SGLI in simple terms",
+        body: [
+          "Servicemembers’ Group Life Insurance, or SGLI, is group life insurance coverage available to eligible service members. It can provide an important foundation during military service.",
+        ],
+      },
+      {
+        heading: "VGLI in simple terms",
+        body: [
+          "Veterans’ Group Life Insurance, or VGLI, allows eligible service members to continue life insurance coverage after service. Costs and eligibility details should be reviewed carefully because family needs and budgets change over time.",
+        ],
+      },
+      {
+        heading: "Burial benefits in simple terms",
+        body: [
+          "Eligible veterans may qualify for burial-related benefits through the VA. These benefits can be helpful, but eligibility, amounts, timing, and covered expenses can vary.",
+        ],
+      },
+      {
+        heading: "Why benefits may help but may not cover everything",
+        body: [
+          "Benefits may support certain needs, but families often also think about mortgage or rent, income replacement, childcare, debts, education goals, and transition time. Those needs may be larger or longer lasting than a single benefit amount.",
+        ],
+      },
+      {
+        heading: "Why private coverage may still be worth reviewing",
+        body: [
+          "Private coverage may provide additional flexibility, ownership, and coverage amounts outside of government or employer programs. Approval, rates, and availability depend on underwriting, state availability, and carrier guidelines.",
+        ],
+      },
+    ],
+    questions: [
+      "What benefits do I currently have, and when do they change?",
+      "Would my family still need income replacement or mortgage support?",
+      "How much coverage would help my family feel stable?",
+      "Do I want coverage I personally own outside of work or military benefits?",
+    ],
+    cta: "Review Veteran Options",
+    sources: [
+      {
+        label: "VA SGLI",
+        href: "https://www.va.gov/life-insurance/options-eligibility/sgli/",
+      },
+      {
+        label: "VA VGLI",
+        href: "https://www.va.gov/life-insurance/options-eligibility/vgli/",
+      },
+      {
+        label: "VA Life Insurance",
+        href: "https://www.va.gov/life-insurance/",
+      },
+      {
+        label: "VA Burial Benefits",
+        href: "https://www.va.gov/burials-memorials/",
+      },
+      {
+        label: "VA National Cemetery Eligibility",
+        href: "https://www.va.gov/burials-memorials/eligibility/",
+      },
+    ],
+    metaDescription:
+      "A plain-English guide comparing SGLI, VGLI, VA burial benefits, and private life insurance considerations for veterans and military families.",
+  },
+  {
+    slug: "retirement-life-insurance",
+    title: "Life Insurance for Retirement Planning",
+    category: "Retirement & Legacy",
+    purpose:
+      "Explain how life insurance may be part of retirement conversations without overpromising.",
+    intro:
+      "Retirement planning is about flexibility, protection, and making thoughtful decisions. Life insurance may be part of that conversation for some families, depending on the policy, funding, goals, and guidance received.",
+    helps: [
+      "Why retirement can change protection needs",
+      "Permanent life insurance and cash value basics",
+      "Why policy design and funding matter",
+      "Why reviewing options with a licensed professional is important",
+    ],
+    sections: [
+      {
+        heading: "Why retirement changes protection needs",
+        body: [
+          "As retirement approaches, families may think differently about income, debt, legacy, long-term care concerns, and surviving spouse needs. Coverage that made sense during working years may need to be reviewed.",
+        ],
+      },
+      {
+        heading: "Permanent life insurance and cash value basics",
+        body: [
+          "Some permanent life insurance policies can build cash value. Cash value features vary by policy type and carrier, and they are subject to policy terms, costs, funding, and performance limitations.",
+        ],
+      },
+      {
+        heading: "Living benefits and access to policy value",
+        body: [
+          "Depending on the policy, some features may allow access to policy value or benefits during life. Access may reduce death benefits, create tax consequences, or depend on specific qualifications. Details should be reviewed before relying on any feature.",
+        ],
+      },
+      {
+        heading: "Why policy design and funding matter",
+        body: [
+          "Life insurance used in retirement planning must be designed carefully. Premiums, fees, policy charges, loan provisions, surrender periods, and funding levels can affect whether a policy remains in force and how it performs.",
+        ],
+      },
+      {
+        heading: "Why professional review matters",
+        body: [
+          "Life insurance should not be presented as a guaranteed retirement income source or investment replacement. A licensed professional can help review whether a policy may fit your protection goals, risk tolerance, budget, and broader retirement plan.",
+        ],
+      },
+    ],
+    questions: [
+      "What protection needs will remain in retirement?",
+      "Do I understand the policy costs and risks?",
+      "Could accessing policy value reduce benefits or create consequences?",
+      "How does this fit with savings, retirement accounts, and other income sources?",
+    ],
+    cta: "Plan With Confidence",
+    sources: [
+      {
+        label: "NAIC Life Insurance Consumer Guide",
+        href: "https://content.naic.org/consumer/life-insurance.htm",
+      },
+      {
+        label: "NAIC Life Insurance Buyer’s Guide PDF",
+        href: "https://content.naic.org/sites/default/files/publication-lig-lp-consumer-life.pdf",
+      },
+      {
+        label: "FINRA Insurance overview",
+        href: "https://www.finra.org/investors/investing/investment-products/insurance",
+      },
+    ],
+    metaDescription:
+      "A careful guide to how life insurance may fit retirement planning, including permanent coverage, cash value basics, policy design, funding, and professional review.",
+  },
+  {
+    slug: "how-much-coverage-do-i-need",
+    title: "How Much Coverage Does My Family Need?",
+    category: "Retirement & Legacy",
+    purpose:
+      "Help families think through coverage needs in a simple, non-intimidating way.",
+    intro:
+      "There is no perfect one-size-fits-all coverage number. A thoughtful estimate starts with the people who depend on you, the responsibilities you carry, and the resources your family already has.",
+    helps: [
+      "How to think about coverage without guessing",
+      "Which expenses families commonly include",
+      "How existing savings and coverage affect the conversation",
+      "What to prepare before speaking with a licensed professional",
+    ],
+    sections: [
+      {
+        heading: "Why there is no one-size-fits-all number",
+        body: [
+          "Two families with the same income may need different coverage because their debts, savings, ages, children, housing costs, and goals are different. The right discussion starts with your life, not a generic number.",
+        ],
+      },
+      {
+        heading: "Income replacement",
+        body: [
+          "If someone depends on your income, coverage may help replace a portion of that income for a period of time. Families often consider how many years of support would be meaningful.",
+        ],
+      },
+      {
+        heading: "Mortgage, rent, debts, childcare, and education",
+        body: [
+          "Common planning categories include housing costs, credit cards, student loans, auto loans, childcare, education goals, and day-to-day living expenses. You do not need exact answers, but estimates are helpful.",
+        ],
+      },
+      {
+        heading: "Final expenses",
+        body: [
+          "Many families include funeral, cremation, burial, or end-of-life costs in their coverage conversation so loved ones have fewer immediate financial decisions to make.",
+        ],
+      },
+      {
+        heading: "Existing savings and coverage",
+        body: [
+          "Savings, retirement accounts, employer life insurance, military or VA benefits, and personally owned policies can all affect how much additional coverage may be needed.",
+        ],
+      },
+    ],
+    questions: [
+      "Who depends on me financially or practically?",
+      "What debts or monthly expenses would remain?",
+      "How much coverage do I already have?",
+      "How long would my family need support?",
+      "What monthly premium fits comfortably in my budget?",
+    ],
+    cta: "Find My Protection Path",
+    sources: [
+      {
+        label: "Life Happens Life Insurance Needs Calculator",
+        href: "https://lifehappens.org/life-insurance-needs-calculator/",
+      },
+      {
+        label: "Life Happens: How much life insurance do I need?",
+        href: "https://lifehappens.org/life-insurance-101/how-much-life-insurance-do-i-need/",
+      },
+      {
+        label: "NAIC Life Insurance Consumer Guide",
+        href: "https://content.naic.org/consumer/life-insurance.htm",
+      },
+    ],
+    metaDescription:
+      "A simple guide to estimating family life insurance coverage needs, including income replacement, mortgage or rent, debts, childcare, education, final expenses, and existing coverage.",
+  },
+];
+
+export const GUIDE_CATEGORIES: GuideCategory[] = [
+  "New Parents",
+  "Homeowners",
+  "Work Benefits",
+  "Final Expense",
+  "Retirement & Legacy",
+  "Veterans & Military Families",
+];
+
+export function getGuideBySlug(slug: string): GuideData | undefined {
+  return GUIDES.find((guide) => guide.slug === slug);
+}
+
+export function getGuidesByCategory(category: GuideCategory): GuideData[] {
+  return GUIDES.filter((guide) => guide.category === category);
+}

--- a/digital-cathedral/app/guides/page.tsx
+++ b/digital-cathedral/app/guides/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function GuidesIndexPage(): never {
+  redirect("/resources");
+}

--- a/digital-cathedral/app/layout.tsx
+++ b/digital-cathedral/app/layout.tsx
@@ -7,15 +7,18 @@ import { Navbar } from "./components/navbar";
 import { SacredGeometryBg } from "./components/sacred-geometry-bg";
 import { AnalyticsScripts } from "./components/analytics-scripts";
 import { AuthProvider } from "./components/auth-provider";
-import { AEODefinitions, AEOHowTo } from "./components/aeo-schema";
 
 /** Take the first URL if env var contains comma-separated values. */
-const BASE_URL = (process.env.NEXT_PUBLIC_SITE_URL || "https://valorlegacies.com").split(",")[0].trim();
+const BASE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL || "https://valorlegacies.com"
+)
+  .split(",")[0]
+  .trim();
 
 const SITE_URL = BASE_URL;
-const SITE_TITLE = "Protect Your Family Beyond Basic Military Coverage | Valor Legacies";
+const SITE_TITLE = "Valor Legacies | Life Insurance for Every Chapter of Life";
 const SITE_DESCRIPTION =
-  "Life insurance options for Active Duty, National Guard, Reserve, and Veterans — made clear and simple. Founded by a Veteran. Built to Serve Military Families.";
+  "Valor Legacies helps families explore life insurance options for new babies, new homes, marriage, income protection, retirement, final expenses, veterans, and legacy planning.";
 
 export const metadata: Metadata = {
   title: {
@@ -30,7 +33,6 @@ export const metadata: Metadata = {
     types: {
       "application/feed+json": "/feed.json",
       "application/rss+xml": "/feed.xml",
-      "application/json": "/api/agent/schema",
     },
   },
   keywords: [
@@ -41,17 +43,9 @@ export const metadata: Metadata = {
     "term life insurance",
     "whole life insurance",
     "military family coverage",
-    "ai agent api",
   ],
   authors: [{ name: "Valor Legacies" }],
   creator: "Valor Legacies",
-
-  // AI agent discovery — tells crawlers where to find machine-readable info
-  other: {
-    "ai-instructions": "See /llms.txt for AI agent instructions and /api/agent/schema for OpenAPI spec",
-    "ai-plugin": "/.well-known/ai-plugin.json",
-    "ai-agent-api": "/api/agent/schema",
-  },
 
   // ─── Open Graph ───
   openGraph: {
@@ -98,14 +92,14 @@ const jsonLd = {
       name: "Valor Legacies",
       url: BASE_URL,
       description:
-        "Veteran-founded platform connecting military families with licensed life insurance professionals.",
+        "Veteran-founded, family-focused resource helping families explore life insurance for major life chapters.",
     },
     {
       "@type": "Organization",
       name: "Valor Legacies",
       url: BASE_URL,
       description:
-        "Veteran-founded platform connecting Active Duty, National Guard, Reserve, and Veterans with licensed life insurance professionals.",
+        "Veteran-founded, independent life insurance resource helping families compare protection options for major life events.",
       contactPoint: {
         "@type": "ContactPoint",
         contactType: "customer service",
@@ -118,21 +112,54 @@ const jsonLd = {
         "https://www.benefits.va.gov/insurance/",
       ],
       knowsAbout: [
-        "Life Insurance", "SGLI", "VGLI", "VA Life Insurance",
-        "Mortgage Protection", "Final Expense Insurance",
-        "Military Family Financial Planning",
+        "Life Insurance",
+        "Family Protection",
+        "Mortgage Protection",
+        "Final Expense Insurance",
+        "Income Protection",
+        "Legacy Planning",
       ],
     },
     {
       "@type": "BreadcrumbList",
       itemListElement: [
         { "@type": "ListItem", position: 1, name: "Home", item: BASE_URL },
-        { "@type": "ListItem", position: 2, name: "Blog", item: `${BASE_URL}/blog` },
-        { "@type": "ListItem", position: 3, name: "Resources", item: `${BASE_URL}/resources` },
-        { "@type": "ListItem", position: 4, name: "About", item: `${BASE_URL}/about` },
-        { "@type": "ListItem", position: 5, name: "FAQ", item: `${BASE_URL}/faq` },
-        { "@type": "ListItem", position: 6, name: "Privacy Policy", item: `${BASE_URL}/privacy` },
-        { "@type": "ListItem", position: 7, name: "Terms of Service", item: `${BASE_URL}/terms` },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "Blog",
+          item: `${BASE_URL}/blog`,
+        },
+        {
+          "@type": "ListItem",
+          position: 3,
+          name: "Resources",
+          item: `${BASE_URL}/resources`,
+        },
+        {
+          "@type": "ListItem",
+          position: 4,
+          name: "About",
+          item: `${BASE_URL}/about`,
+        },
+        {
+          "@type": "ListItem",
+          position: 5,
+          name: "FAQ",
+          item: `${BASE_URL}/faq`,
+        },
+        {
+          "@type": "ListItem",
+          position: 6,
+          name: "Privacy Policy",
+          item: `${BASE_URL}/privacy`,
+        },
+        {
+          "@type": "ListItem",
+          position: 7,
+          name: "Terms of Service",
+          item: `${BASE_URL}/terms`,
+        },
       ],
     },
     {
@@ -142,11 +169,13 @@ const jsonLd = {
         "@type": "Organization",
         name: "Valor Legacies",
       },
-      description: "Free, no-obligation life insurance coverage review for veterans, active duty, National Guard, Reserve, and military families. Connects consumers with licensed insurance professionals.",
+      description:
+        "Free, no-obligation life insurance coverage review for families across life's major chapters. Connects consumers with licensed insurance professionals.",
       areaServed: "US",
       audience: {
         "@type": "Audience",
-        audienceType: "Military families, veterans, active duty service members",
+        audienceType:
+          "Families, veterans, homeowners, parents, spouses, and legacy planners",
       },
       offers: {
         "@type": "Offer",
@@ -154,28 +183,6 @@ const jsonLd = {
         priceCurrency: "USD",
         description: "Free coverage review — no cost, no obligation",
       },
-    },
-    {
-      "@type": "SoftwareApplication",
-      name: "Valor Legacies Agent API",
-      applicationCategory: "BusinessApplication",
-      operatingSystem: "Web",
-      description:
-        "AI agent API for submitting life insurance leads on behalf of veterans and military families. Supports consent-based lead submission, account registration, and OpenAPI discovery.",
-      url: `${BASE_URL}/api/agent/schema`,
-      offers: {
-        "@type": "Offer",
-        price: "0",
-        priceCurrency: "USD",
-        description: "Free API access for authorized AI agents",
-      },
-      featureList: [
-        "Consent-based lead submission",
-        "Account registration",
-        "OpenAPI 3.1 schema discovery",
-        "MCP protocol support",
-        "TCPA/CCPA/FCC 2025 compliant",
-      ],
     },
   ],
 };
@@ -188,21 +195,28 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        {/* AI agent discovery links */}
-        <link rel="ai-instructions" href="/llms.txt" />
-        <link rel="ai-plugin" href="/.well-known/ai-plugin.json" />
-        <link rel="mcp-discovery" href="/.well-known/mcp.json" />
-        <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Valor Legacies Search" />
-        <link rel="alternate" type="application/feed+json" href="/feed.json" title="Valor Legacies JSON Feed" />
-        <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="Valor Legacies RSS Feed" />
-        <link rel="alternate" type="application/json" href="/api/agent/schema" title="Agent API Schema" />
+        <link
+          rel="search"
+          type="application/opensearchdescription+xml"
+          href="/opensearch.xml"
+          title="Valor Legacies Search"
+        />
+        <link
+          rel="alternate"
+          type="application/feed+json"
+          href="/feed.json"
+          title="Valor Legacies JSON Feed"
+        />
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          href="/feed.xml"
+          title="Valor Legacies RSS Feed"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
-        {/* AEO: Answer Engine Optimization — invisible to humans, machine-readable for AI */}
-        <AEODefinitions />
-        <AEOHowTo />
       </head>
       <body className="min-h-screen bg-[var(--bg-deep)]">
         <AuthProvider>
@@ -215,7 +229,8 @@ export default function RootLayout({
         <AnalyticsScripts />
         <script
           dangerouslySetInnerHTML={{
-            __html: "if('serviceWorker' in navigator)navigator.serviceWorker.register('/sw.js')",
+            __html:
+              "if('serviceWorker' in navigator)navigator.serviceWorker.register('/sw.js')",
           }}
         />
       </body>

--- a/digital-cathedral/app/lib/validation.ts
+++ b/digital-cathedral/app/lib/validation.ts
@@ -71,7 +71,26 @@ export const VALID_STATES = new Set([
   "VT","VA","WA","WV","WI","WY",
 ]);
 
-export const VALID_COVERAGE = new Set(["mortgage-protection", "final-expense", "income-replacement", "retirement-savings", "guaranteed-income", "legacy", "newborn-milestones", "not-sure"]);
+export const VALID_COVERAGE = new Set([
+  // Life-chapter homepage values
+  "new-baby",
+  "bought-home",
+  "recently-married",
+  "protect-spouse-family",
+  "income-replacement",
+  "college-planning",
+  "retirement-planning",
+  "legacy",
+  "final-expense",
+  "veteran-military-family",
+  "work-benefits",
+  "not-sure",
+  // Existing campaign/landing-page values kept for backwards compatibility
+  "mortgage-protection",
+  "retirement-savings",
+  "guaranteed-income",
+  "newborn-milestones",
+]);
 export const VALID_PURCHASE_INTENT = new Set(["protect-family", "want-protection", "exploring"]);
 export const VALID_VETERAN_STATUS = new Set([
   "active-duty", "reserve", "national-guard", "veteran",

--- a/digital-cathedral/app/page.tsx
+++ b/digital-cathedral/app/page.tsx
@@ -1,28 +1,17 @@
 "use client";
 
 /**
- * Home Page — Multi-step life insurance lead capture.
+ * Home Page — cinematic life-event life insurance lead capture.
  *
- * Split into:
- *  - useLeadForm hook (multi-step validation, submission, state) → protect/hooks/use-lead-form.ts
- *  - TcpaConsent component (FCC 2025 compliance) → protect/components/tcpa-consent.tsx
- *  - StepProgress component (progress indicator) → protect/components/step-progress.tsx
- *  - This page: composition only
- *
- * Multi-step flow:
- *   Step 1 — Identity:  Name, state, coverage interest (low commitment)
- *   Step 2 — Contact:   Email, phone
- *   Step 3 — Consent:   TCPA + Privacy → submit
+ * Preserves the existing useLeadForm hook, TCPA consent, CSRF-backed lead
+ * submission, UTM tracking, and multi-step validation while replacing the
+ * consumer homepage with a premium chapter-based guided experience.
  */
 
-import { useEffect, useRef, useState, ChangeEvent } from "react";
+import { useEffect, useRef, ChangeEvent } from "react";
 import { useLeadForm, FIELD_STEP } from "./protect/hooks/use-lead-form";
 import { TcpaConsent } from "./protect/components/tcpa-consent";
 import { StepProgress } from "./protect/components/step-progress";
-import { TrustSignals } from "./protect/components/trust-signals";
-import { ImageUpload } from "./components/image-upload";
-import { CoherencyPulse } from "./components/coherency-pulse";
-import { CoherencyVitals } from "./components/coherency-vitals";
 import { useUtmTracking } from "./protect/hooks/use-utm-tracking";
 
 const US_STATES = [
@@ -56,22 +45,83 @@ const US_STATES = [
 ];
 
 const COVERAGE_OPTIONS: { value: string; label: string; description?: string }[] = [
-  { value: "", label: "What do you need protection for?" },
-  { value: "mortgage-protection", label: "Equity / Debt Protection" },
-  { value: "final-expense", label: "Final Expense" },
-  { value: "income-replacement", label: "Income Replacement" },
-  { value: "retirement-savings", label: "Tax-Free Retirement Savings", description: "Best for healthier clients who want flexibility, tax-free loans, and a death benefit" },
-  { value: "guaranteed-income", label: "Guaranteed Retirement Income", description: "Excellent option for clients with significant health issues who want guaranteed lifetime income they can\u2019t outlive" },
-  { value: "legacy", label: "Leave a Legacy" },
-  { value: "newborn-milestones", label: "Newborn / Future Milestones (Wedding, Car, Home, etc.)" },
-  { value: "not-sure", label: "Not sure \u2014 help me decide" },
+  { value: "", label: "What changed in your life?" },
+  { value: "new-baby", label: "We recently had a baby" },
+  { value: "bought-home", label: "We bought a home" },
+  { value: "recently-married", label: "We recently got married" },
+  { value: "protect-spouse-family", label: "I want to protect my spouse or family" },
+  { value: "income-replacement", label: "I want to protect my income" },
+  { value: "college-planning", label: "I want to prepare for college costs" },
+  { value: "retirement-planning", label: "I am planning for retirement" },
+  { value: "legacy", label: "I want to leave a legacy" },
+  { value: "final-expense", label: "I need help with final expenses" },
+  { value: "veteran-military-family", label: "I am a veteran or military family member" },
+  { value: "work-benefits", label: "I am comparing my work benefits" },
+  { value: "not-sure", label: "I’m not sure yet" },
+];
+
+const LIFE_CHAPTERS = [
+  { icon: "✦", title: "Just Had a Baby", desc: "Your family just grew. Now is the time to protect the future they’re just beginning.", cta: "Protect My Growing Family", value: "new-baby" },
+  { icon: "⌂", title: "Bought a Home", desc: "Your home is more than a mortgage. It’s where your family’s life is being built.", cta: "Protect My Home", value: "bought-home" },
+  { icon: "∞", title: "Recently Married", desc: "You’re building a future together. Protection helps keep that future secure.", cta: "Start Planning Together", value: "recently-married" },
+  { icon: "❤", title: "Protecting My Spouse", desc: "If someone depends on your income, love means having a plan.", cta: "Protect My Person", value: "protect-spouse-family" },
+  { icon: "$", title: "Protecting My Income", desc: "Your income supports your life. Protecting it protects the people who rely on you.", cta: "Review Income Protection", value: "income-replacement" },
+  { icon: "◈", title: "Preparing for College", desc: "Plan for tomorrow’s dreams while protecting today’s responsibilities.", cta: "Explore Education Planning", value: "college-planning" },
+  { icon: "☼", title: "Planning Retirement", desc: "Retirement should come with confidence, flexibility, and peace of mind.", cta: "Plan With Confidence", value: "retirement-planning" },
+  { icon: "✧", title: "Leaving a Legacy", desc: "Leave more than memories. Leave love, direction, and protection.", cta: "Build My Legacy", value: "legacy" },
+  { icon: "☾", title: "Final Expense Planning", desc: "Protect your family from the financial weight of funeral and final expenses.", cta: "Plan Final Expenses", value: "final-expense" },
+  { icon: "★", title: "Veteran & Military Family Protection", desc: "Your service protected others. Now let’s help protect the people you love most.", cta: "Review Veteran Options", value: "veteran-military-family" },
+];
+
+const STORY_TIMELINE = [
+  ["First heartbeat", "For the first heartbeat."],
+  ["First front door", "For the first front door."],
+  ["First promise", "For the promise you made."],
+  ["First graduation", "For the dreams ahead."],
+  ["Retirement chapter", "For the years you’ve built."],
+  ["Final wishes", "For the love you leave."],
+];
+
+const SOLUTIONS = [
+  ["Term Life Insurance", "Affordable protection for a specific period of time, often used for income, family, or mortgage protection."],
+  ["Whole Life Insurance", "Permanent coverage with fixed premiums and lifelong protection."],
+  ["Final Expense Insurance", "Coverage designed to help protect loved ones from funeral and final costs."],
+  ["Mortgage Protection", "Life insurance designed to help your family keep or pay off the home if something happens to you."],
+  ["Indexed Universal Life", "Life insurance that can provide protection while building cash value with growth potential."],
+  ["Income Protection", "Coverage designed around replacing income your family depends on."],
+  ["Legacy Planning", "Protection designed to help pass love, values, and financial support to the people who matter most."],
+];
+
+const TRUST_PILLARS = [
+  ["Veteran-Founded", "Rooted in service, protection, and responsibility."],
+  ["Family-Focused", "Every conversation begins with the people you love most."],
+  ["Independent", "We are not limited to one insurance company."],
+  ["Multiple Highly Rated Carriers", "Options may be reviewed from trusted life insurance providers."],
+  ["No-Pressure Guidance", "Education first. Decisions second."],
+  ["Privacy-Minded Process", "Your information is handled with care and respect."],
+];
+
+const RESOURCE_GUIDES = [
+  ["New Parent Protection Checklist", "A simple guide to protecting your growing family after a new baby arrives.", "/guides/new-parent-protection-checklist"],
+  ["Homeowner Protection Guide", "Understand how life insurance can help protect the place your family calls home.", "/guides/homeowner-protection-guide"],
+  ["Is Work Life Insurance Enough?", "Learn where employer coverage can help — and where gaps may remain.", "/guides/employer-life-insurance"],
+  ["Final Expense Planning Guide", "A clear overview of funeral, burial, and end-of-life expense planning.", "/guides/final-expense-planning"],
+  ["Veteran Benefits vs. Private Coverage", "Compare basic benefit conversations with additional family protection options.", "/guides/veteran-benefits-vs-private-coverage"],
+  ["Life Insurance and Retirement Planning", "See how protection may fit into long-term flexibility and confidence.", "/guides/retirement-life-insurance"],
+  ["How Much Coverage Does My Family Need?", "Start thinking through income, debts, home needs, children, and future goals.", "/guides/how-much-coverage-do-i-need"],
+];
+
+const TESTIMONIALS = [
+  ["After our daughter was born, we realized we had no real plan. Valor Legacies helped us understand our options without pressure.", "New parent placeholder"],
+  ["When we bought our home, we wanted to make sure my wife wouldn’t be stuck with the mortgage. The process was simple and clear.", "Homeowner placeholder"],
+  ["As a veteran, I thought my benefits were enough. Valor Legacies helped me understand what my family would still be responsible for.", "Veteran family placeholder"],
 ];
 
 const PURCHASE_INTENT_OPTIONS = [
-  { value: "", label: "How serious are you about coverage?" },
-  { value: "protect-family", label: "I will protect my family" },
-  { value: "want-protection", label: "I want to protect them" },
-  { value: "exploring", label: "I'm just exploring my options" },
+  { value: "", label: "Where are you in the process?" },
+  { value: "protect-family", label: "I’m ready to protect my family" },
+  { value: "want-protection", label: "I want guidance soon" },
+  { value: "exploring", label: "I’m still exploring my options" },
 ];
 
 const MILITARY_STATUS_OPTIONS = [
@@ -84,39 +134,18 @@ const MILITARY_STATUS_OPTIONS = [
   { value: "civilian", label: "Civilian" },
 ];
 
+const AGE_RANGE_OPTIONS = ["", "18-29", "30-39", "40-49", "50-59", "60-69", "70+"];
+const CONTACT_TIME_OPTIONS = ["", "Morning", "Afternoon", "Evening", "No preference"];
 const BRANCH_PLACEHOLDER = { value: "", label: "Select branch of service..." };
-
-const BRANCHES_FULL = [
-  BRANCH_PLACEHOLDER,
-  { value: "army", label: "U.S. Army" },
-  { value: "navy", label: "U.S. Navy" },
-  { value: "air-force", label: "U.S. Air Force" },
-  { value: "marine-corps", label: "U.S. Marine Corps" },
-  { value: "space-force", label: "U.S. Space Force" },
-  { value: "coast-guard", label: "Coast Guard" },
-];
-
-const BRANCHES_NO_SPACE = [
-  BRANCH_PLACEHOLDER,
-  { value: "army", label: "U.S. Army" },
-  { value: "navy", label: "U.S. Navy" },
-  { value: "air-force", label: "U.S. Air Force" },
-  { value: "marine-corps", label: "U.S. Marine Corps" },
-  { value: "coast-guard", label: "Coast Guard" },
-];
-
+const BRANCHES_FULL = [BRANCH_PLACEHOLDER, { value: "army", label: "U.S. Army" }, { value: "navy", label: "U.S. Navy" }, { value: "air-force", label: "U.S. Air Force" }, { value: "marine-corps", label: "U.S. Marine Corps" }, { value: "space-force", label: "U.S. Space Force" }, { value: "coast-guard", label: "Coast Guard" }];
+const BRANCHES_NO_SPACE = [BRANCH_PLACEHOLDER, { value: "army", label: "U.S. Army" }, { value: "navy", label: "U.S. Navy" }, { value: "air-force", label: "U.S. Air Force" }, { value: "marine-corps", label: "U.S. Marine Corps" }, { value: "coast-guard", label: "Coast Guard" }];
 const BRANCH_OPTIONS_BY_STATUS: Record<string, { value: string; label: string }[]> = {
   "active-duty": BRANCHES_FULL,
   "reserve": BRANCHES_NO_SPACE,
-  "national-guard": [
-    BRANCH_PLACEHOLDER,
-    { value: "air-national-guard", label: "Air National Guard" },
-    { value: "army-national-guard", label: "Army National Guard" },
-  ],
+  "national-guard": [BRANCH_PLACEHOLDER, { value: "air-national-guard", label: "Air National Guard" }, { value: "army-national-guard", label: "Army National Guard" }],
   "veteran": BRANCHES_FULL,
 };
 
-// Live formats as user types: (555) 123-4567
 function formatPhoneInput(value: string): string {
   const digits = value.replace(/\D/g, "").slice(0, 10);
   if (digits.length === 0) return "";
@@ -125,605 +154,449 @@ function formatPhoneInput(value: string): string {
   return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
 }
 
-// Auto-capitalize names as user types
 function autoCapitalizeName(value: string): string {
   return value.replace(/(?:^|\s|[-'])([a-z])/g, (match) => match.toUpperCase());
 }
 
-const INPUT_CLASS =
-  "w-full bg-gray-50 text-black placeholder-gray-400 border rounded-lg px-4 py-3 text-sm focus:outline-none transition-all";
-const INPUT_NORMAL = INPUT_CLASS + " border-gray-300 focus:border-teal-cathedral/60";
-const INPUT_ERROR = INPUT_CLASS + " border-red-500 border-2 bg-red-50/30 focus:border-red-500";
-const SELECT_NORMAL = INPUT_NORMAL + " appearance-none";
-const SELECT_ERROR = INPUT_ERROR + " appearance-none";
-
-function inputClass(hasError: boolean) { return hasError ? INPUT_ERROR : INPUT_NORMAL; }
-function selectClass(hasError: boolean) { return hasError ? SELECT_ERROR : SELECT_NORMAL; }
-const LABEL_CLASS = "block text-sm font-bold text-gray-900";
-const BTN_PRIMARY = "py-3 rounded-lg font-medium text-sm transition-all bg-teal-cathedral text-white hover:bg-teal-cathedral/90 hover:shadow-[0_0_30px_rgba(0,168,168,0.15)]";
-const BTN_BACK = "py-3 rounded-lg font-medium text-sm transition-all text-gray-500 border border-gray-300 hover:border-gray-400";
-const SECTION_HEADING = "text-2xl md:text-3xl font-light text-[var(--text-primary)]";
+const INPUT_CLASS = "w-full rounded-2xl border border-[#d9cdbb] bg-white/90 px-4 py-3 text-sm text-[#201b16] placeholder-[#8a7d6d] shadow-inner shadow-black/5 transition-all focus:border-[#b58b3b] focus:outline-none focus:ring-2 focus:ring-[#c8a85d]/25";
+const INPUT_ERROR = INPUT_CLASS + " border-red-500 bg-red-50/70 focus:border-red-500 focus:ring-red-200";
+const SELECT_CLASS = INPUT_CLASS + " appearance-none";
+const LABEL_CLASS = "block text-sm font-semibold text-[#2a2219]";
+const BTN_PRIMARY = "rounded-full bg-[#b58b3b] px-7 py-3 text-sm font-semibold text-white shadow-[0_18px_45px_rgba(82,55,17,0.28)] transition-all hover:-translate-y-0.5 hover:bg-[#9f782f] focus-visible:outline-[#f4d58d]";
+const BTN_SECONDARY = "rounded-full border border-[#d9c08a]/55 bg-white/10 px-7 py-3 text-sm font-semibold text-white backdrop-blur transition-all hover:-translate-y-0.5 hover:bg-white/15";
+const BTN_BACK = "rounded-full border border-[#d9cdbb] px-6 py-3 text-sm font-semibold text-[#6c5a40] transition-all hover:border-[#b58b3b]";
+const SECTION_LABEL = "mb-4 text-xs font-semibold uppercase tracking-[0.32em] text-[#b58b3b]";
+const SECTION_HEADING = "font-serif text-3xl font-light leading-tight text-[#211a13] md:text-5xl";
 
 const NEXT_STEPS = [
-  { title: "Confirmation Email", desc: "Check your inbox for a confirmation of your request." },
-  { title: "Professional Review", desc: "A licensed insurance professional in your area will review your information and coverage needs." },
-  { title: "Personal Consultation", desc: "Expect a call or email within 1 business day to discuss your options — no obligation." },
+  { title: "Careful Review", desc: "Your request is reviewed so your family receives thoughtful, relevant guidance." },
+  { title: "Professional Follow-Up", desc: "A licensed professional may contact you to discuss options for your life and goals." },
+  { title: "No-Pressure Clarity", desc: "You decide what feels right. Submission does not guarantee coverage or approval." },
 ];
 
 const FOOTER_LINKS = [
+  { href: "/", label: "Home" },
+  { href: "/#life-chapters", label: "Life Chapters" },
+  { href: "/resources", label: "Guides" },
   { href: "/about", label: "About" },
-  { href: "/faq", label: "FAQ" },
   { href: "/privacy", label: "Privacy Policy" },
-  { href: "/terms", label: "Terms of Service" },
+  { href: "/terms", label: "Terms" },
+  { href: "https://valorlegacies.xyz", label: "Agent/Admin Portal" },
 ];
 
-const DEFAULT_VETERAN_STORY = [
-  "As a veteran, I know what it means to carry responsibility both while you\u2019re wearing the uniform and long after it\u2019s folded away. During my time in service and especially after I transitioned to civilian life, I saw something that really bothered me. A lot of military families believed their standard coverage was enough\u2026 but they were never given the full picture about the life insurance options actually available to them.",
-  "Too many of us were left in the dark. That\u2019s why I created this platform.",
-  "My mission is simple: to make sure every service member and their families finally get clear, honest information so they can make the best decisions for the people they love.",
-  "When you request a review, we\u2019ll connect you with trusted, independent, licensed professionals who truly understand the unique needs of military families. No pressure. Just real guidance and options that actually fit your life.",
-  "Because the service we gave our country doesn\u2019t end when we take the uniform off, and neither should the protection we give our families.",
-].join("\n");
+function inputClass(hasError: boolean) { return hasError ? INPUT_ERROR : INPUT_CLASS; }
+function selectClass(hasError: boolean) { return hasError ? INPUT_ERROR + " appearance-none" : SELECT_CLASS; }
 
 export default function HomePage() {
   const utm = useUtmTracking();
-
-  // Fetch editable veteran story from API
-  const [veteranStory, setVeteranStory] = useState(DEFAULT_VETERAN_STORY);
-  useEffect(() => {
-    fetch("/api/site-content")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.content?.veteranStory) {
-          setVeteranStory(data.content.veteranStory);
-        }
-      })
-      .catch(() => {}); // fallback to default on error
-  }, []);
   const {
-    form, errors, loading, submitted, confirmationMessage, leadId, coherency, serverError,
+    form, errors, loading, submitted, confirmationMessage, leadId, serverError,
     step, totalSteps, submitAttempted, missingFields,
     updateField, handleSubmit, nextStep, prevStep, goToStep,
   } = useLeadForm({ ...utm });
 
-  // --- Accessibility: focus management on step change ---
   const stepContainerRef = useRef<HTMLDivElement>(null);
   const prevStepRef = useRef(step);
 
   useEffect(() => {
     if (step !== prevStepRef.current) {
       prevStepRef.current = step;
-      // Focus the first input in the new step after render
       requestAnimationFrame(() => {
-        const container = stepContainerRef.current;
-        if (container) {
-          const firstInput = container.querySelector<HTMLElement>("input, select");
-          firstInput?.focus();
-        }
+        const firstInput = stepContainerRef.current?.querySelector<HTMLElement>("input, select, textarea");
+        firstInput?.focus();
       });
     }
   }, [step]);
 
+  function chooseChapter(value: string) {
+    updateField("coverageInterest", value);
+    document.getElementById("protection-path")?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
   if (submitted) {
     return (
-      <main className="min-h-screen flex flex-col items-center justify-center px-4 py-12" aria-label="Form submission confirmation">
-        {/* Success icon */}
-        <div className="mb-8">
-          <div className="w-20 h-20 rounded-full bg-teal-cathedral/10 flex items-center justify-center mx-auto">
-            <svg className="w-10 h-10 text-teal-cathedral" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-            </svg>
-          </div>
-        </div>
-
-        <div className="w-full max-w-lg cathedral-surface p-8 cathedral-glow text-center" role="status">
-          <div className="text-teal-cathedral text-sm tracking-[0.3em] uppercase mb-4 pulse-gentle">
-            Request Received
-          </div>
-          <h1 className="text-3xl font-light text-[var(--text-primary)] mb-3">
-            Thank You, {form.firstName}
-          </h1>
-          <p className="text-[var(--text-primary)] text-lg mb-6">
-            Your Legacy is Being Protected
-          </p>
-          <p className="text-teal-cathedral italic opacity-90 text-base leading-relaxed mb-8">
-            &ldquo;{confirmationMessage}&rdquo;
-          </p>
-
-          {/* Coherency pulse — the submitter's own signal through the Covenant Gate.
-              Visible only when the API returned a shape (newer covenant-gate path). */}
-          {coherency && coherency.shape.length >= 4 ? (
-            <div className="mb-8 flex justify-center">
-              <CoherencyPulse
-                label="Your Signal"
-                shape={coherency.shape}
-                score={coherency.score}
-                tier={coherency.tier.charAt(0).toUpperCase() + coherency.tier.slice(1)}
-                archetype={coherency.dominantArchetype}
-                size="md"
-              />
-            </div>
-          ) : null}
-
-          {/* Reference number */}
+      <main className="min-h-screen bg-[#f6f0e6] px-4 py-16 text-[#241d15]" aria-label="Form submission confirmation">
+        <section className="mx-auto max-w-2xl rounded-[2rem] border border-[#d9c08a]/45 bg-white p-8 text-center shadow-[0_24px_80px_rgba(55,39,20,0.12)] md:p-12">
+          <div className="mx-auto mb-8 flex h-20 w-20 items-center justify-center rounded-full bg-[#1f1a14] text-3xl text-[#d6b35f]" aria-hidden="true">✓</div>
+          <p className={SECTION_LABEL}>Request Received</p>
+          <h1 className="font-serif text-4xl font-light md:text-5xl">Thank you, {form.firstName}.</h1>
+          <p className="mx-auto mt-5 max-w-xl text-lg leading-relaxed text-[#6a5c4b]">{confirmationMessage || "Your protection path request has been received. A licensed professional will be in touch soon."}</p>
           {leadId && (
-            <div className="bg-[var(--bg-surface)] rounded-lg px-4 py-3 mb-8 inline-block">
-              <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-1">Reference Number</p>
-              <p className="text-sm font-mono text-[var(--text-primary)] select-all">{leadId}</p>
+            <div className="mx-auto my-8 inline-block rounded-2xl bg-[#f6f0e6] px-5 py-3 text-left">
+              <p className="text-xs uppercase tracking-[0.24em] text-[#8c7550]">Reference Number</p>
+              <p className="mt-1 font-mono text-sm text-[#241d15]">{leadId}</p>
             </div>
           )}
-
-          {/* What happens next */}
-          <div className="border-t border-indigo-cathedral/8 pt-6 mt-2">
-            <h2 className="text-sm font-medium text-[var(--text-primary)] uppercase tracking-wider mb-4">What Happens Next</h2>
-            <div className="space-y-4 text-left">
-              {NEXT_STEPS.map((s, i) => (
-                <div key={i} className="flex gap-3 items-start">
-                  <div className="w-7 h-7 rounded-full bg-teal-cathedral text-white flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">{i + 1}</div>
-                  <div>
-                    <p className="text-sm text-[var(--text-primary)] font-medium">{s.title}</p>
-                    <p className="text-xs text-[var(--text-muted)]">{s.desc}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
+          <div className="mt-8 grid gap-4 border-t border-[#eadfce] pt-8 text-left md:grid-cols-3">
+            {NEXT_STEPS.map((item, index) => (
+              <div key={item.title}>
+                <div className="mb-3 flex h-8 w-8 items-center justify-center rounded-full bg-[#d6b35f] text-sm font-bold text-white">{index + 1}</div>
+                <h2 className="text-sm font-semibold">{item.title}</h2>
+                <p className="mt-2 text-sm leading-relaxed text-[#6a5c4b]">{item.desc}</p>
+              </div>
+            ))}
           </div>
-        </div>
-
-        {/* Navigation links */}
-        <div className="flex gap-4 mt-8">
-          <a
-            href="/"
-            className="px-6 py-3 rounded-lg text-sm font-medium border border-indigo-cathedral/10 text-[var(--text-muted)] hover:border-indigo-cathedral/25 transition-all"
-          >
-            Return Home
-          </a>
-          <a
-            href="/privacy"
-            className="px-6 py-3 rounded-lg text-sm font-medium text-teal-cathedral hover:text-teal-cathedral/80 transition-all"
-          >
-            Privacy Policy
-          </a>
-        </div>
-
-        <footer className="mt-16 text-center text-xs text-[var(--text-muted)] space-y-2">
-          <p>Protecting what matters most — your family.</p>
-          <p>&copy; {new Date().getFullYear()} Valor Legacies. All rights reserved.</p>
-        </footer>
+          <a href="/" className="mt-10 inline-flex rounded-full bg-[#201913] px-7 py-3 text-sm font-semibold text-white">Return Home</a>
+        </section>
       </main>
     );
   }
 
-  const coverageDesc = COVERAGE_OPTIONS.find((o) => o.value === form.coverageInterest)?.description;
-
   return (
-    <main className="min-h-screen flex flex-col items-center px-4 py-12">
-      {/* Veteran Story — First thing visitors see */}
-      <section className="w-full max-w-2xl mb-16 px-4" aria-labelledby="veteran-founded-heading-top">
-        <h2 id="veteran-founded-heading-top" className={`${SECTION_HEADING} mb-6 text-center`}>
-          Dedicated to Serving Those Who Served.
-        </h2>
-
-        {/* Veteran group photo — display only (upload via admin portal) */}
-        <ImageUpload
-          slot="veteran-group"
-          alt="Military service members group photo"
-          editable={false}
-          className="w-full max-w-xl mx-auto mb-8 rounded-lg bg-[var(--bg-surface)] border border-teal-cathedral/20 flex items-center justify-center overflow-hidden"
-          imgClassName="w-full h-auto object-cover rounded-lg"
-          fallback={
-            <div className="w-full h-48 flex items-center justify-center">
-              <svg className="w-12 h-12 text-[var(--text-muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
-              </svg>
+    <main className="overflow-hidden bg-[#f6f0e6] text-[#241d15]">
+      <section id="home" className="relative flex min-h-[92vh] items-center px-4 py-24 text-white md:px-8" aria-labelledby="hero-heading">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_20%,rgba(214,179,95,0.34),transparent_28%),linear-gradient(120deg,rgba(19,16,13,0.96),rgba(31,25,19,0.82)_45%,rgba(65,45,24,0.5)),url('/og-image.svg')] bg-cover bg-center" aria-hidden="true" />
+        <div className="absolute inset-0 bg-gradient-to-b from-black/20 via-black/20 to-[#f6f0e6]" aria-hidden="true" />
+        <div className="relative mx-auto grid w-full max-w-7xl items-center gap-12 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="animate-valor-rise max-w-4xl">
+            <p className="mb-5 text-sm font-semibold uppercase tracking-[0.35em] text-[#d6b35f]">Life changes. Love lives on.</p>
+            <p className="font-serif text-2xl text-[#f6e5c4] md:text-4xl">For the life you live...</p>
+            <p className="mt-2 font-serif text-2xl text-[#f6e5c4] md:text-4xl">...and the love you leave.</p>
+            <h1 id="hero-heading" className="mt-7 max-w-4xl font-serif text-5xl font-light leading-[0.98] tracking-[-0.04em] md:text-7xl lg:text-8xl">Every New Chapter Deserves Protection.</h1>
+            <p className="mt-7 max-w-2xl text-lg leading-8 text-[#f8ead2] md:text-xl">Life changes in beautiful, unexpected, and meaningful ways. Valor Legacies helps families find life insurance guidance for the moments that matter most.</p>
+            <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+              <a href="#protection-path" className={BTN_PRIMARY}>Find My Protection Path</a>
+              <a href="#life-chapters" className={BTN_SECONDARY}>Explore Life Chapters</a>
             </div>
-          }
-        />
-
-        <div className="text-sm leading-relaxed max-w-xl mx-auto text-center">
-          <div className="metallic-gold">
-            {veteranStory.split("\n").filter(Boolean).map((para: string, i: number) => (
-              <p key={i} className="mb-4 last:mb-0">{para}</p>
-            ))}
           </div>
-          <p className="text-xs text-[var(--text-muted)] mt-4 pt-4 border-t border-indigo-cathedral/8">
-            We are not affiliated with the U.S. Government or Department of Defense. We connect
-            individuals with independent, licensed insurance professionals.
-          </p>
+          <div className="animate-valor-rise hidden rounded-[2rem] border border-white/15 bg-white/10 p-5 shadow-[0_30px_90px_rgba(0,0,0,0.28)] backdrop-blur md:block">
+            <div className="rounded-[1.5rem] bg-gradient-to-br from-[#f6e5c4]/95 to-[#b58b3b]/80 p-8 text-[#211a13]">
+              <p className="text-xs font-semibold uppercase tracking-[0.28em]">Guided protection</p>
+              <p className="mt-16 font-serif text-4xl leading-tight">A quiet plan for the people who matter most.</p>
+              <p className="mt-6 text-sm leading-7 text-[#4b3a25]">Video-ready hero area: replace this panel or background with a silent brand story montage when assets are available.</p>
+            </div>
+          </div>
         </div>
       </section>
 
-      {/* The Gap Most Don't Realize Exists */}
-      <section className="w-full max-w-2xl mb-16 px-4 text-center" aria-labelledby="gap-heading">
-        <h2 id="gap-heading" className="text-lg md:text-xl font-light text-red-500 mb-6">
-          Your Service Protects Others. But Is Your Family Fully Protected?
-        </h2>
-        <div className="text-sm text-[var(--text-muted)] leading-relaxed text-left max-w-xl mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4 text-center text-[var(--text-primary)]">
-            <p>
-              Many service members rely solely on SGLI or assume their coverage will always be enough.
-            </p>
-            <p>
-              But coverage limits, conversion timelines, and post-service changes can create unexpected gaps.
-            </p>
+      <section id="life-chapters" className="px-4 py-20 md:px-8 md:py-28" aria-labelledby="life-chapters-heading">
+        <div className="mx-auto max-w-7xl">
+          <div className="mx-auto max-w-3xl text-center">
+            <p className={SECTION_LABEL}>Start with your moment</p>
+            <h2 id="life-chapters-heading" className={SECTION_HEADING}>What Chapter Are You In?</h2>
+            <p className="mt-5 text-lg leading-8 text-[#6a5c4b]">You do not need to know what type of life insurance you need. Start with the moment that brought you here.</p>
           </div>
+          <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+            {LIFE_CHAPTERS.map((chapter) => (
+              <button key={chapter.title} type="button" onClick={() => chooseChapter(chapter.value)} className="group rounded-[1.5rem] border border-[#decda9] bg-white/80 p-5 text-left shadow-[0_18px_60px_rgba(61,43,24,0.08)] transition-all hover:-translate-y-1 hover:border-[#c8a85d] hover:bg-white hover:shadow-[0_26px_70px_rgba(61,43,24,0.14)] focus-visible:outline-[#b58b3b]">
+                <span className="mb-6 flex h-11 w-11 items-center justify-center rounded-full bg-[#241d15] text-lg text-[#d6b35f]">{chapter.icon}</span>
+                <h3 className="font-serif text-xl leading-tight text-[#241d15]">{chapter.title}</h3>
+                <p className="mt-3 min-h-[84px] text-sm leading-6 text-[#6a5c4b]">{chapter.desc}</p>
+                <span className="mt-5 inline-flex text-sm font-semibold text-[#9f782f] group-hover:underline">{chapter.cta}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
 
-          {/* Serving Every Stage of Service */}
-          <h3 className="text-xl md:text-2xl font-light tracking-wide text-teal-cathedral text-center mt-14 mb-6">
-            Serving Every Stage of Service.
-          </h3>
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+      <section className="bg-[#211a13] px-4 py-20 text-white md:px-8 md:py-28" aria-labelledby="story-heading">
+        <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+          <div>
+            <p className={SECTION_LABEL}>Valor Legacies</p>
+            <h2 id="story-heading" className="font-serif text-4xl font-light leading-tight md:text-6xl">Life changes. Love lives on.</h2>
+            <p className="mt-6 text-lg leading-8 text-[#eadcc7]">From the first heartbeat to the first home, from wedding vows to retirement plans, every chapter carries love, responsibility, and meaning. Valor Legacies helps families protect what matters today while preparing for what comes tomorrow.</p>
+            <p className="mt-8 font-serif text-3xl text-[#d6b35f]">Valor Legacies.</p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {STORY_TIMELINE.map(([title, caption], index) => (
+              <div key={title} className="rounded-3xl border border-white/10 bg-white/[0.06] p-5 backdrop-blur">
+                <div className="mb-8 flex h-10 w-10 items-center justify-center rounded-full border border-[#d6b35f]/55 text-sm text-[#d6b35f]">{index + 1}</div>
+                <h3 className="font-serif text-2xl">{title}</h3>
+                <p className="mt-2 text-sm text-[#eadcc7]">{caption}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="px-4 py-20 md:px-8 md:py-28" aria-labelledby="how-heading">
+        <div className="mx-auto max-w-6xl text-center">
+          <p className={SECTION_LABEL}>A calmer way forward</p>
+          <h2 id="how-heading" className={SECTION_HEADING}>You Don’t Have to Figure This Out Alone.</h2>
+          <div className="mt-12 grid gap-6 md:grid-cols-3">
             {[
-              "Active Duty Service Members",
-              "National Guard",
-              "Reserve Members",
-              "Veterans",
-              "Military Families",
-              "Transitioning Service Members",
-            ].map((category) => (
-              <div key={category} className="cathedral-surface border-2 border-teal-cathedral/40 p-4 text-center">
-                <p className="text-sm text-[var(--text-primary)] font-medium">{category}</p>
+              ["Tell us what changed.", "Choose the life event or concern that brought you here."],
+              ["Understand your options.", "We help make life insurance simple, clear, and relatable."],
+              ["Get guidance that fits your life.", "A licensed professional can help review options based on your needs, goals, health, and budget."],
+            ].map(([title, desc], index) => (
+              <div key={title} className="rounded-[1.75rem] bg-white p-8 text-left shadow-[0_20px_70px_rgba(61,43,24,0.08)]">
+                <div className="mb-8 flex h-12 w-12 items-center justify-center rounded-full bg-[#d6b35f] font-bold text-white">{index + 1}</div>
+                <h3 className="font-serif text-2xl text-[#241d15]">{title}</h3>
+                <p className="mt-4 leading-7 text-[#6a5c4b]">{desc}</p>
               </div>
             ))}
           </div>
-          <p className="text-sm metallic-gold text-center font-medium mt-6">
-            If you&rsquo;ve served — this is for you.
-          </p>
-
+          <p className="mx-auto mt-8 max-w-2xl rounded-full bg-white/70 px-6 py-3 text-sm text-[#6a5c4b]">Every request is carefully reviewed before a licensed professional follows up, so families receive thoughtful, relevant guidance.</p>
         </div>
       </section>
 
-      {/* Section 3: How It Works */}
-      <section className="w-full max-w-2xl mb-16 px-4 text-center" aria-labelledby="how-it-works-heading">
-        <h2 id="how-it-works-heading" className={`${SECTION_HEADING} mb-8`}>
-          Simple. Structured. Secure.
-        </h2>
-        <div className="grid md:grid-cols-3 gap-6">
-          {[
-            { step: "1", title: "Submit", desc: "Submit a short, secure form." },
-            { step: "2", title: "Connect", desc: "We connect you with a licensed professional experienced in military family coverage." },
-            { step: "3", title: "Review", desc: "Review your options and decide what\u2019s right for your family." },
-          ].map((item) => (
-            <div key={item.step} className="cathedral-surface p-6 text-center">
-              <div className="w-10 h-10 rounded-full bg-teal-cathedral text-white flex items-center justify-center text-sm font-medium mx-auto mb-3">
-                {item.step}
+      <section id="solutions" className="bg-white px-4 py-20 md:px-8 md:py-28" aria-labelledby="solutions-heading">
+        <div className="mx-auto max-w-7xl">
+          <div className="max-w-3xl">
+            <p className={SECTION_LABEL}>Not product-first</p>
+            <h2 id="solutions-heading" className={SECTION_HEADING}>Protection Designed Around Your Life</h2>
+            <p className="mt-5 text-lg leading-8 text-[#6a5c4b]">You do not need to know which policy fits before reaching out. That is exactly what guidance is for.</p>
+          </div>
+          <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+            {SOLUTIONS.map(([title, desc]) => (
+              <div key={title} className="rounded-[1.5rem] border border-[#eadfce] bg-[#fbf7f0] p-6 transition-all hover:-translate-y-1 hover:border-[#d6b35f]">
+                <h3 className="font-serif text-2xl text-[#241d15]">{title}</h3>
+                <p className="mt-4 text-sm leading-7 text-[#6a5c4b]">{desc}</p>
               </div>
-              <h3 className="text-sm font-medium text-[var(--text-primary)] mb-2">{item.title}</h3>
-              <p className="text-xs text-[var(--text-muted)] leading-relaxed">{item.desc}</p>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-        <p className="text-sm text-[var(--text-muted)] mt-6 italic">
-          No pressure. No obligation. Just clarity.
-        </p>
       </section>
 
-      {/* Live substrate vitals — degrades gracefully if endpoint unavailable */}
-      <CoherencyVitals />
-
-      {/* Hero — Above the Form */}
-      <header className="text-center mb-10">
-        <div className="text-teal-cathedral text-lg tracking-[0.3em] uppercase mb-3 pulse-gentle">
-          Protect What Matters Most
-        </div>
-        <h1 className={`${SECTION_HEADING} mb-4`}>
-          Protect Your Family Beyond Basic Military Coverage.
-        </h1>
-        <p className="metallic-gold max-w-lg mx-auto text-sm leading-relaxed mb-3">
-          Life insurance options for Active Duty, National Guard, Reserve, and Veterans
-          — made clear and simple.
-        </p>
-        <p className="text-teal-cathedral text-xs tracking-wide font-medium">
-          Founded by a Veteran. Built to Serve Military Families.
-        </p>
-      </header>
-
-      {/* Disclaimer — above form */}
-      <div className="w-full max-w-lg mb-6 text-xs text-[var(--text-muted)] text-center leading-relaxed">
-        <p>
-          This website is not an insurance company and does not provide insurance quotes,
-          bind coverage, or offer insurance advice. We connect consumers with licensed
-          insurance professionals. All coverage is subject to underwriting approval.
-        </p>
-      </div>
-
-      {/* Screen reader: live region for step changes */}
-      <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {`Step ${step + 1} of ${totalSteps}: ${["Your Identity", "Contact Information", "Review and Consent"][step]}`}
-      </div>
-
-      {/* Multi-Step Lead Capture Form */}
-      <form onSubmit={handleSubmit} className="w-full max-w-lg bg-[#9E9E9E] text-black rounded-[13px] shadow-[0_0_34px_rgba(0,168,168,0.12)] p-6 md:p-8 space-y-6" noValidate aria-label="Life insurance quote request form">
-        {/* Honeypot field — hidden from humans, visible to bots */}
-        <div aria-hidden="true" style={{ position: "absolute", left: "-9999px", top: "-9999px", opacity: 0, height: 0, overflow: "hidden" }}>
-          <label htmlFor="_hp_website">Website</label>
-          <input
-            id="_hp_website"
-            name="website"
-            type="text"
-            value={form._hp_website}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("_hp_website", e.target.value)}
-            tabIndex={-1}
-            autoComplete="off"
-          />
-        </div>
-
-        {/* Step Progress Indicator */}
-        <StepProgress currentStep={step} totalSteps={totalSteps} />
-
-        {/* --- Step 0: Identity --- */}
-        {step === 0 && (
-          <div ref={stepContainerRef} className="space-y-5 animate-in fade-in" role="group" aria-label="Step 1: Your Identity">
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-1">
-                <label htmlFor="firstName" className={LABEL_CLASS}>First Name</label>
-                <input id="firstName" type="text" value={form.firstName} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("firstName", autoCapitalizeName(e.target.value))} placeholder="John" autoComplete="given-name" aria-required="true" aria-invalid={!!errors.firstName} aria-describedby={errors.firstName ? "firstName-error" : undefined} className={inputClass(!!errors.firstName)} />
-                {errors.firstName && <p id="firstName-error" className="text-crimson-cathedral text-xs" role="alert">{errors.firstName}</p>}
+      <section className="px-4 py-20 md:px-8 md:py-28" aria-labelledby="trust-heading">
+        <div className="mx-auto max-w-7xl">
+          <div className="mx-auto max-w-3xl text-center">
+            <p className={SECTION_LABEL}>Trust pillars</p>
+            <h2 id="trust-heading" className={SECTION_HEADING}>Guided by Service. Built on Trust.</h2>
+          </div>
+          <div className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {TRUST_PILLARS.map(([title, desc]) => (
+              <div key={title} className="rounded-[1.5rem] border border-[#decda9] bg-white/80 p-6">
+                <h3 className="font-serif text-2xl text-[#241d15]">{title}</h3>
+                <p className="mt-3 leading-7 text-[#6a5c4b]">{desc}</p>
               </div>
-              <div className="space-y-1">
-                <label htmlFor="lastName" className={LABEL_CLASS}>Last Name</label>
-                <input id="lastName" type="text" value={form.lastName} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("lastName", autoCapitalizeName(e.target.value))} placeholder="Doe" autoComplete="family-name" aria-required="true" aria-invalid={!!errors.lastName} aria-describedby={errors.lastName ? "lastName-error" : undefined} className={inputClass(!!errors.lastName)} />
-                {errors.lastName && <p id="lastName-error" className="text-crimson-cathedral text-xs" role="alert">{errors.lastName}</p>}
-              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="guides" className="bg-[#211a13] px-4 py-20 text-white md:px-8 md:py-28" aria-labelledby="guides-heading">
+        <div className="mx-auto max-w-7xl">
+          <div className="max-w-3xl">
+            <p className={SECTION_LABEL}>Resource center</p>
+            <h2 id="guides-heading" className="font-serif text-4xl font-light md:text-6xl">Learn Before You Decide</h2>
+            <p className="mt-5 text-lg text-[#eadcc7]">Helpful guides for life’s biggest moments.</p>
+          </div>
+          <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+            {RESOURCE_GUIDES.map(([title, desc, href]) => (
+              <a key={title} href={href} className="rounded-[1.5rem] border border-white/10 bg-white/[0.06] p-6 transition-all hover:-translate-y-1 hover:border-[#d6b35f]/60">
+                <h3 className="font-serif text-2xl">{title}</h3>
+                <p className="mt-3 min-h-[78px] text-sm leading-7 text-[#eadcc7]">{desc}</p>
+                <span className="text-sm font-semibold text-[#d6b35f]">Read Guide</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="protection-path" className="px-4 py-20 md:px-8 md:py-28" aria-labelledby="form-heading">
+        <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
+          <div className="lg:sticky lg:top-24">
+            <p className={SECTION_LABEL}>Protection path</p>
+            <h2 id="form-heading" className={SECTION_HEADING}>Find Your Protection Path</h2>
+            <p className="mt-5 text-lg leading-8 text-[#6a5c4b]">Start with what changed in your life. We’ll help guide the next step.</p>
+            <div className="mt-8 rounded-[1.5rem] border border-[#decda9] bg-white/75 p-6 text-sm leading-7 text-[#6a5c4b]">
+              <strong className="text-[#241d15]">Privacy-minded guidance.</strong> By submitting this form, you agree to be contacted by Valor Legacies or a licensed insurance professional regarding life insurance options. Message and data rates may apply. Submission does not guarantee coverage or approval.
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className="rounded-[2rem] border border-[#decda9] bg-white p-5 shadow-[0_30px_90px_rgba(61,43,24,0.12)] md:p-8" noValidate aria-label="Life insurance protection path form">
+            <div aria-hidden="true" style={{ position: "absolute", left: "-9999px", top: "-9999px", opacity: 0, height: 0, overflow: "hidden" }}>
+              <label htmlFor="_hp_website">Website</label>
+              <input id="_hp_website" name="website" type="text" value={form._hp_website} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("_hp_website", e.target.value)} tabIndex={-1} autoComplete="off" />
             </div>
 
-            <div className="space-y-1">
-              <label htmlFor="dateOfBirth" className={LABEL_CLASS}>Date of Birth</label>
-              <input
-                id="dateOfBirth"
-                type="date"
-                value={form.dateOfBirth}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("dateOfBirth", e.target.value)}
-                autoComplete="bday"
-                aria-required="true"
-                aria-invalid={!!errors.dateOfBirth}
-                aria-describedby={errors.dateOfBirth ? "dob-error dob-hint" : "dob-hint"}
-                className={inputClass(!!errors.dateOfBirth)}
-              />
-              <p id="dob-hint" className="text-crimson-cathedral text-xs">You must be at least 18 years old.</p>
-              {errors.dateOfBirth && <p id="dob-error" className="text-crimson-cathedral text-xs" role="alert">{errors.dateOfBirth}</p>}
-            </div>
+            <StepProgress currentStep={step} totalSteps={totalSteps} />
+            <div aria-live="polite" aria-atomic="true" className="sr-only">{`Step ${step + 1} of ${totalSteps}: ${["Your Life Chapter", "Contact Details", "Review and Consent"][step]}`}</div>
 
-            <div className="space-y-1">
-              <label htmlFor="state" className={LABEL_CLASS}>State</label>
-              <select id="state" value={form.state} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("state", e.target.value)} aria-required="true" aria-invalid={!!errors.state} aria-describedby={errors.state ? "state-error" : undefined} className={selectClass(!!errors.state)}>
-                <option value="">Select your state...</option>
-                {US_STATES.map((s) => <option key={s.code} value={s.code}>{s.name}</option>)}
-              </select>
-              {errors.state && <p id="state-error" className="text-crimson-cathedral text-xs" role="alert">{errors.state}</p>}
-            </div>
+            {step === 0 && (
+              <div ref={stepContainerRef} className="mt-8 space-y-5 animate-in fade-in" role="group" aria-label="Step 1: Your Life Chapter">
+                <div className="space-y-2">
+                  <label htmlFor="coverage" className={LABEL_CLASS}>What changed in your life that made you start thinking about protection?</label>
+                  <select id="coverage" value={form.coverageInterest} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("coverageInterest", e.target.value)} aria-required="true" aria-invalid={!!errors.coverageInterest} aria-describedby={errors.coverageInterest ? "coverage-error" : undefined} className={selectClass(!!errors.coverageInterest)}>
+                    {COVERAGE_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+                  </select>
+                  {errors.coverageInterest && <p id="coverage-error" className="text-xs text-red-600" role="alert">{errors.coverageInterest}</p>}
+                </div>
 
-            <div className="space-y-1">
-              <label htmlFor="coverage" className={LABEL_CLASS}>Coverage Interest</label>
-              <select id="coverage" value={form.coverageInterest} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("coverageInterest", e.target.value)} aria-required="true" aria-invalid={!!errors.coverageInterest} aria-describedby={errors.coverageInterest ? "coverage-error" : (coverageDesc ? "coverage-desc" : undefined)} className={selectClass(!!errors.coverageInterest)}>
-                {COVERAGE_OPTIONS.map((opt) => <option key={opt.value} value={opt.value} title={opt.description}>{opt.label}</option>)}
-              </select>
-              {coverageDesc && <p id="coverage-desc" className="text-xs text-[var(--text-muted)]">{coverageDesc}</p>}
-              {errors.coverageInterest && <p id="coverage-error" className="text-crimson-cathedral text-xs" role="alert">{errors.coverageInterest}</p>}
-            </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <label htmlFor="firstName" className={LABEL_CLASS}>First Name</label>
+                    <input id="firstName" type="text" value={form.firstName} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("firstName", autoCapitalizeName(e.target.value))} placeholder="Jane" autoComplete="given-name" aria-required="true" aria-invalid={!!errors.firstName} className={inputClass(!!errors.firstName)} />
+                    {errors.firstName && <p className="text-xs text-red-600" role="alert">{errors.firstName}</p>}
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="lastName" className={LABEL_CLASS}>Last Name</label>
+                    <input id="lastName" type="text" value={form.lastName} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("lastName", autoCapitalizeName(e.target.value))} placeholder="Doe" autoComplete="family-name" aria-required="true" aria-invalid={!!errors.lastName} className={inputClass(!!errors.lastName)} />
+                    {errors.lastName && <p className="text-xs text-red-600" role="alert">{errors.lastName}</p>}
+                  </div>
+                </div>
 
-            <div className="space-y-1">
-              <label htmlFor="purchaseIntent" className={LABEL_CLASS}>How Serious Are You?</label>
-              <select id="purchaseIntent" value={form.purchaseIntent} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("purchaseIntent", e.target.value)} aria-required="true" aria-invalid={!!errors.purchaseIntent} aria-describedby={errors.purchaseIntent ? "intent-error" : undefined} className={selectClass(!!errors.purchaseIntent)}>
-                {PURCHASE_INTENT_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-              </select>
-              {errors.purchaseIntent && <p id="intent-error" className="text-crimson-cathedral text-xs" role="alert">{errors.purchaseIntent}</p>}
-            </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <label htmlFor="ageRange" className={LABEL_CLASS}>Age Range</label>
+                    <select id="ageRange" value={form.ageRange} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("ageRange", e.target.value)} className={selectClass(false)}>
+                      {AGE_RANGE_OPTIONS.map((opt) => <option key={opt || "blank"} value={opt}>{opt || "Select age range..."}</option>)}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="dateOfBirth" className={LABEL_CLASS}>Date of Birth</label>
+                    <input id="dateOfBirth" type="date" value={form.dateOfBirth} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("dateOfBirth", e.target.value)} autoComplete="bday" aria-required="true" aria-invalid={!!errors.dateOfBirth} className={inputClass(!!errors.dateOfBirth)} />
+                    <p className="text-xs text-[#8a6a3a]">Required to route accurate life insurance guidance. You must be at least 18.</p>
+                    {errors.dateOfBirth && <p className="text-xs text-red-600" role="alert">{errors.dateOfBirth}</p>}
+                  </div>
+                </div>
 
-            {/* Background — service members, families, and civilians all welcome */}
-            <div className="space-y-1">
-              <label htmlFor="veteranStatus" className={LABEL_CLASS}>Your Background</label>
-              <p className="text-xs text-[var(--text-muted)]" id="veteran-hint">
-                Veterans, service members, military families, and civilians are all welcome — we match every request to a licensed professional.
-              </p>
-              <select id="veteranStatus" value={form.veteranStatus} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("veteranStatus", e.target.value)} aria-required="true" aria-invalid={!!errors.veteranStatus} aria-describedby={errors.veteranStatus ? "veteran-error" : "veteran-hint"} className={selectClass(!!errors.veteranStatus)}>
-                {MILITARY_STATUS_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-              </select>
-              {errors.veteranStatus && <p id="veteran-error" className="text-crimson-cathedral text-xs" role="alert">{errors.veteranStatus}</p>}
-            </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <label htmlFor="state" className={LABEL_CLASS}>State</label>
+                    <select id="state" value={form.state} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("state", e.target.value)} aria-required="true" aria-invalid={!!errors.state} className={selectClass(!!errors.state)}>
+                      <option value="">Select your state...</option>
+                      {US_STATES.map((s) => <option key={s.code} value={s.code}>{s.name}</option>)}
+                    </select>
+                    {errors.state && <p className="text-xs text-red-600" role="alert">{errors.state}</p>}
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="purchaseIntent" className={LABEL_CLASS}>Readiness</label>
+                    <select id="purchaseIntent" value={form.purchaseIntent} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("purchaseIntent", e.target.value)} aria-required="true" aria-invalid={!!errors.purchaseIntent} className={selectClass(!!errors.purchaseIntent)}>
+                      {PURCHASE_INTENT_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+                    </select>
+                    {errors.purchaseIntent && <p className="text-xs text-red-600" role="alert">{errors.purchaseIntent}</p>}
+                  </div>
+                </div>
 
-            {/* Branch of Service — conditional subcategory (shown for all except non-military) */}
-            {form.veteranStatus && form.veteranStatus !== "non-military" && form.veteranStatus !== "civilian" && BRANCH_OPTIONS_BY_STATUS[form.veteranStatus] && (
-              <div className="space-y-1 animate-in fade-in">
-                <label htmlFor="militaryBranch" className={LABEL_CLASS}>Branch of Service</label>
-                <select id="militaryBranch" value={form.militaryBranch} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("militaryBranch", e.target.value)} aria-required="true" aria-invalid={!!errors.militaryBranch} aria-describedby={errors.militaryBranch ? "branch-error branch-hint" : "branch-hint"} className={selectClass(!!errors.militaryBranch)}>
-                  {BRANCH_OPTIONS_BY_STATUS[form.veteranStatus].map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-                </select>
-                <p id="branch-hint" className="text-gray-500 text-xs">Thank you for your service.</p>
-                {errors.militaryBranch && <p id="branch-error" className="text-crimson-cathedral text-xs" role="alert">{errors.militaryBranch}</p>}
+                <button type="button" onClick={nextStep} className={`w-full ${BTN_PRIMARY}`}>Continue My Path</button>
               </div>
             )}
 
-            {/* Next button */}
-            <button
-              type="button"
-              onClick={nextStep}
-              className={`w-full ${BTN_PRIMARY}`}
-            >
-              Continue
-            </button>
-          </div>
-        )}
+            {step === 1 && (
+              <div ref={stepContainerRef} className="mt-8 space-y-5 animate-in fade-in" role="group" aria-label="Step 2: Contact Details">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <label htmlFor="phone" className={LABEL_CLASS}>Phone</label>
+                    <input id="phone" type="tel" value={form.phone} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("phone", formatPhoneInput(e.target.value))} placeholder="(555) 123-4567" autoComplete="tel" aria-required="true" aria-invalid={!!errors.phone} className={inputClass(!!errors.phone)} />
+                    {errors.phone && <p className="text-xs text-red-600" role="alert">{errors.phone}</p>}
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="email" className={LABEL_CLASS}>Email</label>
+                    <input id="email" type="email" value={form.email} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("email", e.target.value)} placeholder="jane@example.com" autoComplete="email" aria-required="true" aria-invalid={!!errors.email} className={inputClass(!!errors.email)} />
+                    {errors.email && <p className="text-xs text-red-600" role="alert">{errors.email}</p>}
+                  </div>
+                </div>
 
-        {/* --- Step 1: Contact --- */}
-        {step === 1 && (
-          <div ref={stepContainerRef} className="space-y-5 animate-in fade-in" role="group" aria-label="Step 2: Contact Information">
-            <div className="space-y-1">
-              <label htmlFor="email" className={LABEL_CLASS}>Email Address</label>
-              <input id="email" type="email" value={form.email} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("email", e.target.value)} placeholder="john.doe@example.com" autoComplete="email" aria-required="true" aria-invalid={!!errors.email} aria-describedby={errors.email ? "email-error" : undefined} className={inputClass(!!errors.email)} />
-              {errors.email && <p id="email-error" className="text-crimson-cathedral text-xs" role="alert">{errors.email}</p>}
-            </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <label htmlFor="preferredContactTime" className={LABEL_CLASS}>Preferred Contact Time</label>
+                    <select id="preferredContactTime" value={form.preferredContactTime} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("preferredContactTime", e.target.value)} className={selectClass(false)}>
+                      {CONTACT_TIME_OPTIONS.map((opt) => <option key={opt || "blank"} value={opt}>{opt || "Select a time..."}</option>)}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="veteranStatus" className={LABEL_CLASS}>Background</label>
+                    <select id="veteranStatus" value={form.veteranStatus} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("veteranStatus", e.target.value)} aria-required="true" aria-invalid={!!errors.veteranStatus} className={selectClass(!!errors.veteranStatus)}>
+                      {MILITARY_STATUS_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+                    </select>
+                    {errors.veteranStatus && <p className="text-xs text-red-600" role="alert">{errors.veteranStatus}</p>}
+                  </div>
+                </div>
 
-            <div className="space-y-1">
-              <label htmlFor="phone" className={LABEL_CLASS}>Phone Number</label>
-              <input id="phone" type="tel" value={form.phone} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("phone", formatPhoneInput(e.target.value))} placeholder="(555) 123-4567" autoComplete="tel" aria-required="true" aria-invalid={!!errors.phone} aria-describedby={errors.phone ? "phone-error" : undefined} className={inputClass(!!errors.phone)} />
-              {errors.phone && <p id="phone-error" className="text-crimson-cathedral text-xs" role="alert">{errors.phone}</p>}
-            </div>
-
-            {/* Navigation */}
-            <div className="flex gap-3">
-              <button
-                type="button"
-                onClick={prevStep}
-                className={`flex-1 ${BTN_BACK}`}
-              >
-                Back
-              </button>
-              <button
-                type="button"
-                onClick={nextStep}
-                className={`flex-1 ${BTN_PRIMARY}`}
-              >
-                Continue
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* --- Step 2: Consent & Submit --- */}
-        {step === 2 && (
-          <div ref={stepContainerRef} className="space-y-5 animate-in fade-in" role="group" aria-label="Step 3: Review and Consent">
-            {/* Review summary */}
-            <div className="bg-gray-50 rounded-[13px] p-4 text-sm space-y-1" role="region" aria-label="Review your information">
-              <p className="text-gray-500 text-xs uppercase tracking-wider mb-2">Your Information</p>
-              <p className="text-black font-medium">{form.firstName} {form.lastName}</p>
-              <p className="text-gray-600">DOB: {form.dateOfBirth}</p>
-              <p className="text-gray-600">{form.email}</p>
-              <p className="text-gray-600">{form.phone}</p>
-              <p className="text-gray-600">
-                {US_STATES.find(s => s.code === form.state)?.name} &middot;{" "}
-                {COVERAGE_OPTIONS.find(o => o.value === form.coverageInterest)?.label}
-              </p>
-              <p className="text-gray-600">
-                {PURCHASE_INTENT_OPTIONS.find(o => o.value === form.purchaseIntent)?.label}
-              </p>
-              <p className="text-gray-600">
-                {MILITARY_STATUS_OPTIONS.find(o => o.value === form.veteranStatus)?.label}
-                {form.veteranStatus && form.veteranStatus !== "non-military" && form.veteranStatus !== "civilian" && form.militaryBranch && (
-                  <> &middot; {BRANCH_OPTIONS_BY_STATUS[form.veteranStatus]?.find(o => o.value === form.militaryBranch)?.label}</>
+                {form.veteranStatus && form.veteranStatus !== "non-military" && form.veteranStatus !== "civilian" && BRANCH_OPTIONS_BY_STATUS[form.veteranStatus] && (
+                  <div className="space-y-2 animate-in fade-in">
+                    <label htmlFor="militaryBranch" className={LABEL_CLASS}>Branch of Service</label>
+                    <select id="militaryBranch" value={form.militaryBranch} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("militaryBranch", e.target.value)} aria-required="true" aria-invalid={!!errors.militaryBranch} className={selectClass(!!errors.militaryBranch)}>
+                      {BRANCH_OPTIONS_BY_STATUS[form.veteranStatus].map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+                    </select>
+                    <p className="text-xs text-[#8a6a3a]">Thank you for your service.</p>
+                    {errors.militaryBranch && <p className="text-xs text-red-600" role="alert">{errors.militaryBranch}</p>}
+                  </div>
                 )}
-              </p>
-              <button
-                type="button"
-                onClick={() => prevStep()}
-                className="text-teal-cathedral text-xs underline mt-1"
-              >
-                Edit information
-              </button>
-            </div>
 
-            <div className="border-t border-gray-200 pt-5" />
+                <div className="space-y-2">
+                  <label htmlFor="message" className={LABEL_CLASS}>Optional Message</label>
+                  <textarea id="message" value={form.message} onChange={(e: ChangeEvent<HTMLTextAreaElement>) => updateField("message", e.target.value)} rows={4} className={inputClass(false)} placeholder="Anything you’d like us to know about your family, goals, or timing?" />
+                </div>
 
-            {/* TCPA + Privacy Consent */}
-            <TcpaConsent
-              tcpaChecked={form.tcpaConsent}
-              privacyChecked={form.privacyConsent}
-              onTcpaChange={(v) => updateField("tcpaConsent", v)}
-              onPrivacyChange={(v) => updateField("privacyConsent", v)}
-              tcpaError={errors.tcpaConsent}
-              privacyError={errors.privacyConsent}
-            />
-
-            {/* Server Error */}
-            {serverError && (
-              <div className="text-crimson-cathedral text-sm text-center py-2" role="alert" aria-live="assertive">{serverError}</div>
-            )}
-
-            {/* Missing Fields Summary — shown after submit attempt */}
-            {submitAttempted && missingFields.length > 0 && (
-              <div className="rounded-lg border-2 border-red-400 bg-red-50 p-4" role="alert" aria-live="assertive" id="missing-fields-summary">
-                <p className="text-red-700 font-bold text-sm mb-2">Please complete the following fields before submitting:</p>
-                <ul className="list-disc list-inside space-y-1">
-                  {missingFields.map((mf) => (
-                    <li key={mf.field} className="text-red-600 text-sm">
-                      <button
-                        type="button"
-                        className="text-red-600 underline hover:text-red-800 font-medium"
-                        onClick={() => {
-                          const targetStep = FIELD_STEP[mf.field];
-                          if (targetStep !== step) {
-                            goToStep(targetStep);
-                          }
-                          // Wait for React to render the target step, then scroll + focus
-                          setTimeout(() => {
-                            const idMap: Record<string, string> = { coverageInterest: "coverage" };
-                            const elId = idMap[mf.field] || mf.field;
-                            const el = document.getElementById(elId);
-                            if (el) {
-                              el.scrollIntoView({ behavior: "smooth", block: "center" });
-                              el.focus();
-                            }
-                          }, 100);
-                        }}
-                      >
-                        {mf.label}
-                      </button>
-                      <span className="text-red-500 text-xs ml-1">— {mf.error}</span>
-                    </li>
-                  ))}
-                </ul>
+                <div className="flex gap-3">
+                  <button type="button" onClick={prevStep} className={`flex-1 ${BTN_BACK}`}>Back</button>
+                  <button type="button" onClick={nextStep} className={`flex-1 ${BTN_PRIMARY}`}>Continue</button>
+                </div>
               </div>
             )}
 
-            {/* Navigation + Submit */}
-            <div className="flex gap-3">
-              <button
-                type="button"
-                onClick={prevStep}
-                className={`flex-1 ${BTN_BACK}`}
-              >
-                Back
-              </button>
-              <button
-                type="submit"
-                disabled={loading}
-                aria-busy={loading}
-                className={`flex-1 ${BTN_PRIMARY} disabled:opacity-40 disabled:cursor-not-allowed`}
-              >
-                {loading ? "Submitting..." : "Request My Coverage Review"}
-              </button>
-            </div>
-            <p className="text-center text-xs text-gray-500 mt-2">No pressure. No obligation. Just clear options.</p>
+            {step === 2 && (
+              <div ref={stepContainerRef} className="mt-8 space-y-5 animate-in fade-in" role="group" aria-label="Step 3: Review and Consent">
+                <div className="rounded-3xl bg-[#f6f0e6] p-5 text-sm leading-7">
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-[0.24em] text-[#9f782f]">Review Your Path</p>
+                  <p className="font-semibold text-[#241d15]">{form.firstName} {form.lastName}</p>
+                  <p>{COVERAGE_OPTIONS.find(o => o.value === form.coverageInterest)?.label}</p>
+                  <p>{form.phone} · {form.email}</p>
+                  <p>{US_STATES.find(s => s.code === form.state)?.name} {form.ageRange ? `· Age ${form.ageRange}` : ""}</p>
+                  <button type="button" onClick={() => prevStep()} className="mt-2 text-sm font-semibold text-[#9f782f] underline">Edit information</button>
+                </div>
+
+                <TcpaConsent tcpaChecked={form.tcpaConsent} privacyChecked={form.privacyConsent} onTcpaChange={(v) => updateField("tcpaConsent", v)} onPrivacyChange={(v) => updateField("privacyConsent", v)} tcpaError={errors.tcpaConsent} privacyError={errors.privacyConsent} />
+
+                <p className="rounded-2xl bg-[#f6f0e6] p-4 text-xs leading-6 text-[#6a5c4b]">By submitting this form, you agree to be contacted by Valor Legacies or a licensed insurance professional regarding life insurance options. Message and data rates may apply. Submission does not guarantee coverage or approval.</p>
+
+                {serverError && <div className="text-center text-sm text-red-600" role="alert" aria-live="assertive">{serverError}</div>}
+                {submitAttempted && missingFields.length > 0 && (
+                  <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700" role="alert">
+                    <p className="font-semibold">Please review:</p>
+                    <ul className="mt-2 list-disc pl-5">
+                      {missingFields.map((m) => <li key={m.field}><button type="button" className="underline" onClick={() => goToStep(FIELD_STEP[m.field])}>{m.label}: {m.error}</button></li>)}
+                    </ul>
+                  </div>
+                )}
+
+                <div className="flex gap-3">
+                  <button type="button" onClick={prevStep} className={`flex-1 ${BTN_BACK}`}>Back</button>
+                  <button type="submit" disabled={loading} className={`flex-1 ${BTN_PRIMARY} disabled:cursor-not-allowed disabled:opacity-60`}>{loading ? "Sending..." : "Start My Protection Path"}</button>
+                </div>
+              </div>
+            )}
+          </form>
+        </div>
+      </section>
+
+      <section className="bg-white px-4 py-20 md:px-8 md:py-28" aria-labelledby="testimonials-heading">
+        <div className="mx-auto max-w-7xl">
+          <p className={SECTION_LABEL}>Stories to replace with approved testimonials</p>
+          <h2 id="testimonials-heading" className={SECTION_HEADING}>Families Come Here at Real Moments.</h2>
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            {TESTIMONIALS.map(([quote, label]) => (
+              <figure key={label} className="rounded-[1.5rem] bg-[#fbf7f0] p-6 shadow-[0_18px_60px_rgba(61,43,24,0.08)]">
+                <blockquote className="font-serif text-2xl leading-snug text-[#241d15]">“{quote}”</blockquote>
+                <figcaption className="mt-5 text-xs font-semibold uppercase tracking-[0.2em] text-[#9f782f]">{label}</figcaption>
+              </figure>
+            ))}
           </div>
-        )}
-      </form>
+        </div>
+      </section>
 
-      {/* Below-Form Disclaimers */}
-      <div className="w-full max-w-lg mt-6 space-y-3 text-xs text-[var(--text-muted)] leading-relaxed">
-        <p>
-          <strong className="text-[var(--text-primary)]">Important:</strong> This website is operated by Valor Legacies
-          and is not an insurance company, insurance agent, or insurance broker. We do not provide insurance
-          quotes, bind insurance coverage, or provide insurance advice of any kind. Your information will
-          be shared with one or more licensed insurance professionals who may contact you. Any insurance
-          products or coverage are subject to the terms, conditions, and eligibility requirements of
-          the applicable insurance company.
-        </p>
-        <p>
-          Coverage availability, rates, and terms vary by state. Not all applicants will qualify for
-          coverage. No guarantee of specific rates or coverage is implied.
-        </p>
-      </div>
+      <section id="about" className="px-4 py-20 md:px-8 md:py-28" aria-labelledby="about-heading">
+        <div className="mx-auto grid max-w-7xl gap-10 rounded-[2rem] bg-[#241d15] p-8 text-white md:p-12 lg:grid-cols-[1fr_0.7fr] lg:items-center">
+          <div>
+            <p className={SECTION_LABEL}>Our story</p>
+            <h2 id="about-heading" className="font-serif text-4xl font-light md:text-6xl">Veteran-Founded. Family-Focused. Independent.</h2>
+            <p className="mt-6 text-lg leading-8 text-[#eadcc7]">Valor Legacies was created to help families make confident decisions during life’s most important transitions. Founded by a veteran, our mission is rooted in service, protection, and legacy. We are independent, which means we are not limited to one insurance company. We help families understand options that fit their life, budget, and goals.</p>
+            <a href="/about" className="mt-8 inline-flex rounded-full bg-[#d6b35f] px-7 py-3 text-sm font-semibold text-[#241d15]">Our Story</a>
+          </div>
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/[0.06] p-6">
+            <p className="font-serif text-3xl text-[#f6e5c4]">For the life you live and the love you leave.</p>
+            <p className="mt-5 text-sm leading-7 text-[#eadcc7]">Independent guidance, rooted in service, for families across life’s biggest chapters.</p>
+          </div>
+        </div>
+      </section>
 
-      {/* Do Not Sell Link — CCPA Compliance */}
-      <div className="w-full max-w-lg mt-4 text-center">
-        <a href="/privacy#do-not-sell" className="text-xs text-teal-cathedral underline">
-          Do Not Sell or Share My Personal Information
-        </a>
-      </div>
-
-      {/* Trust Signals — Social Proof & How It Works */}
-      <div className="w-full flex justify-center mt-16 px-4">
-        <TrustSignals />
-      </div>
-
-      {/* Footer */}
-      <footer className="mt-16 text-center text-xs text-[var(--text-muted)] space-y-2">
-        <nav className="flex gap-4 justify-center flex-wrap">
-          {FOOTER_LINKS.map((l) => (
-            <a key={l.href} href={l.href} className="text-teal-cathedral/70 hover:text-teal-cathedral">{l.label}</a>
-          ))}
-        </nav>
-        <p>&copy; {new Date().getFullYear()} Valor Legacies. All rights reserved.</p>
+      <footer className="bg-[#15110d] px-4 py-12 text-[#eadcc7] md:px-8">
+        <div className="mx-auto grid max-w-7xl gap-8 md:grid-cols-[1.2fr_0.8fr_1.2fr]">
+          <div>
+            <p className="font-serif text-3xl text-white">Valor Legacies</p>
+            <p className="mt-3 text-[#d6b35f]">For the life you live and the love you leave.</p>
+          </div>
+          <nav className="grid grid-cols-2 gap-3 text-sm" aria-label="Footer navigation">
+            {FOOTER_LINKS.map((l) => <a key={l.href} href={l.href} className="hover:text-white">{l.label}</a>)}
+          </nav>
+          <div className="text-xs leading-6 text-[#b9aa95]">
+            <p>Valor Legacies is not an insurance company. We are an independent life insurance resource and may connect consumers with licensed insurance professionals. Coverage availability, rates, and approval are subject to state availability, underwriting, and carrier guidelines. Valor Legacies is not affiliated with the U.S. Department of Veterans Affairs, the Department of Defense, or any government agency.</p>
+            <p className="mt-4">&copy; {new Date().getFullYear()} Valor Legacies. All rights reserved.</p>
+          </div>
+        </div>
       </footer>
     </main>
   );

--- a/digital-cathedral/app/portal/dashboard/page.tsx
+++ b/digital-cathedral/app/portal/dashboard/page.tsx
@@ -58,10 +58,10 @@ export default function PortalDashboardPage() {
   const [msgSuccess, setMsgSuccess] = useState("");
 
   useEffect(() => {
-    // Contextual tab title — the layout default is "Agent Portal | Valor
-    // Legacies"; this overrides for the dashboard specifically so an open
+    // Contextual tab title — the layout default is "Valor Legacies Agent &
+    // Admin Portal"; this overrides for the dashboard specifically so an open
     // tab is identifiable at a glance.
-    document.title = "Agent Dashboard | Valor Legacies";
+    document.title = "Agent Dashboard | Valor Legacies Agent & Admin Portal";
 
     fetch("/api/portal/session")
       .then((res) => {
@@ -119,14 +119,18 @@ export default function PortalDashboardPage() {
   if (loading) {
     return (
       <main className="min-h-screen flex items-center justify-center">
-        <div className="text-[var(--text-muted)] text-sm">Loading your portal...</div>
+        <div className="text-[var(--text-muted)] text-sm">
+          Loading your portal...
+        </div>
       </main>
     );
   }
 
   if (!user) return null;
 
-  const unreadCount = messages.filter((m) => m.direction === "outbound" && !m.read).length;
+  const unreadCount = messages.filter(
+    (m) => m.direction === "outbound" && !m.read,
+  ).length;
 
   const tabs: { key: Tab; label: string; badge?: number }[] = [
     { key: "quotes", label: "Quotes & Status" },
@@ -182,12 +186,14 @@ export default function PortalDashboardPage() {
             role="status"
             className="px-4 py-3 rounded-lg text-sm bg-amber-50 text-amber-800 border border-amber-200"
           >
-            <strong className="block mb-0.5">Awaiting license verification.</strong>
+            <strong className="block mb-0.5">
+              Awaiting license verification.
+            </strong>
             <span>
-              We&apos;re reviewing your insurance license. You&apos;ll get an email once
-              your account is activated — typical turnaround is one business day.
-              The marketplace and lead purchase will unlock automatically when
-              that happens.
+              We&apos;re reviewing your insurance license. You&apos;ll get an
+              email once your account is activated — typical turnaround is one
+              business day. The marketplace and lead purchase will unlock
+              automatically when that happens.
             </span>
           </div>
         )}
@@ -196,7 +202,9 @@ export default function PortalDashboardPage() {
             role="alert"
             className="px-4 py-3 rounded-lg text-sm bg-amber-50 text-amber-800 border border-amber-200"
           >
-            <strong className="block mb-0.5">Account temporarily suspended.</strong>
+            <strong className="block mb-0.5">
+              Account temporarily suspended.
+            </strong>
             <span>
               Your account is on hold pending review. Reach out to support and
               we&apos;ll resolve it as quickly as we can.
@@ -241,11 +249,14 @@ export default function PortalDashboardPage() {
         {/* Tab content */}
         {activeTab === "quotes" && (
           <div className="space-y-4">
-            <h2 className="text-lg font-medium text-[var(--text-primary)]">Your Quotes & Submissions</h2>
+            <h2 className="text-lg font-medium text-[var(--text-primary)]">
+              Your Quotes & Submissions
+            </h2>
             {leads.length === 0 ? (
               <div className="cathedral-surface p-8 text-center">
                 <p className="text-[var(--text-muted)] text-sm">
-                  No leads yet. Browse the marketplace to find leads matching your criteria.
+                  No leads yet. Browse the marketplace to find leads matching
+                  your criteria.
                 </p>
                 <Link
                   href="/portal/marketplace"
@@ -257,14 +268,18 @@ export default function PortalDashboardPage() {
             ) : (
               <div className="space-y-3">
                 {leads.map((lead) => (
-                  <div key={lead.leadId} className="cathedral-surface p-4 flex items-center justify-between">
+                  <div
+                    key={lead.leadId}
+                    className="cathedral-surface p-4 flex items-center justify-between"
+                  >
                     <div>
                       <div className="text-sm font-medium text-[var(--text-primary)]">
                         {lead.coverageInterest || "Life Insurance Quote"}
                       </div>
                       <div className="text-xs text-[var(--text-muted)] mt-1">
                         {lead.state && `${lead.state} · `}
-                        Submitted {new Date(lead.createdAt).toLocaleDateString()}
+                        Submitted{" "}
+                        {new Date(lead.createdAt).toLocaleDateString()}
                       </div>
                     </div>
                     <span className="px-3 py-1 text-xs rounded-full bg-amber-500/10 text-amber-400 border border-amber-500/20">
@@ -279,17 +294,23 @@ export default function PortalDashboardPage() {
 
         {activeTab === "documents" && (
           <div className="space-y-4">
-            <h2 className="text-lg font-medium text-[var(--text-primary)]">Your Documents</h2>
+            <h2 className="text-lg font-medium text-[var(--text-primary)]">
+              Your Documents
+            </h2>
             {documents.length === 0 ? (
               <div className="cathedral-surface p-8 text-center">
                 <p className="text-[var(--text-muted)] text-sm">
-                  No documents yet. Once your policy is set up, documents will appear here for download.
+                  No documents yet. Once your policy is set up, documents will
+                  appear here for download.
                 </p>
               </div>
             ) : (
               <div className="space-y-3">
                 {documents.map((doc) => (
-                  <div key={doc.id} className="cathedral-surface p-4 flex items-center justify-between">
+                  <div
+                    key={doc.id}
+                    className="cathedral-surface p-4 flex items-center justify-between"
+                  >
                     <div className="flex items-center gap-3">
                       <svg
                         width="20"
@@ -303,9 +324,12 @@ export default function PortalDashboardPage() {
                         <path d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
                       </svg>
                       <div>
-                        <div className="text-sm font-medium text-[var(--text-primary)]">{doc.name}</div>
+                        <div className="text-sm font-medium text-[var(--text-primary)]">
+                          {doc.name}
+                        </div>
                         <div className="text-xs text-[var(--text-muted)]">
-                          {doc.type} · Uploaded {new Date(doc.createdAt).toLocaleDateString()}
+                          {doc.type} · Uploaded{" "}
+                          {new Date(doc.createdAt).toLocaleDateString()}
                         </div>
                       </div>
                     </div>
@@ -326,11 +350,18 @@ export default function PortalDashboardPage() {
 
         {activeTab === "messages" && (
           <div className="space-y-6">
-            <h2 className="text-lg font-medium text-[var(--text-primary)]">Messages</h2>
+            <h2 className="text-lg font-medium text-[var(--text-primary)]">
+              Messages
+            </h2>
 
             {/* Compose form */}
-            <form onSubmit={handleSendMessage} className="cathedral-surface p-4 space-y-3">
-              <div className="text-sm font-medium text-[var(--text-primary)]">Send a Message</div>
+            <form
+              onSubmit={handleSendMessage}
+              className="cathedral-surface p-4 space-y-3"
+            >
+              <div className="text-sm font-medium text-[var(--text-primary)]">
+                Send a Message
+              </div>
               <input
                 type="text"
                 placeholder="Subject (optional)"
@@ -373,12 +404,16 @@ export default function PortalDashboardPage() {
                   <div
                     key={msg.id}
                     className={`cathedral-surface p-4 ${
-                      msg.direction === "outbound" && !msg.read ? "border-l-2 border-teal-cathedral" : ""
+                      msg.direction === "outbound" && !msg.read
+                        ? "border-l-2 border-teal-cathedral"
+                        : ""
                     }`}
                   >
                     <div className="flex items-center justify-between mb-1">
                       <span className="text-xs font-medium text-[var(--text-muted)]">
-                        {msg.direction === "inbound" ? "You" : "Valor Legacies Team"}
+                        {msg.direction === "inbound"
+                          ? "You"
+                          : "Valor Legacies Team"}
                       </span>
                       <span className="text-xs text-[var(--text-muted)]">
                         {new Date(msg.createdAt).toLocaleString()}
@@ -389,7 +424,9 @@ export default function PortalDashboardPage() {
                         {msg.subject}
                       </div>
                     )}
-                    <p className="text-sm text-[var(--text-muted)] whitespace-pre-wrap">{msg.body}</p>
+                    <p className="text-sm text-[var(--text-muted)] whitespace-pre-wrap">
+                      {msg.body}
+                    </p>
                   </div>
                 ))}
               </div>

--- a/digital-cathedral/app/portal/layout.tsx
+++ b/digital-cathedral/app/portal/layout.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
   title: {
-    template: "%s | Valor Legacies Agent Portal",
-    default: "Agent Portal | Valor Legacies",
+    template: "%s | Valor Legacies Agent & Admin Portal",
+    default: "Valor Legacies Agent & Admin Portal",
   },
 };
 

--- a/digital-cathedral/app/protect/hooks/use-lead-form.ts
+++ b/digital-cathedral/app/protect/hooks/use-lead-form.ts
@@ -59,6 +59,9 @@ export interface LeadFormData {
   purchaseIntent: string;
   veteranStatus: string;
   militaryBranch: string;
+  ageRange: string;
+  preferredContactTime: string;
+  message: string;
   tcpaConsent: boolean;
   privacyConsent: boolean;
   // Honeypot field — must remain empty for humans
@@ -90,8 +93,8 @@ export const FIELD_LABELS: Record<keyof LeadFormErrors, string> = {
   email: "Email Address",
   phone: "Phone Number",
   state: "State",
-  coverageInterest: "Coverage Interest",
-  purchaseIntent: "How Serious Are You",
+  coverageInterest: "What Changed",
+  purchaseIntent: "Readiness",
   veteranStatus: "Your Background",
   militaryBranch: "Branch of Service",
   tcpaConsent: "TCPA Consent",
@@ -151,7 +154,7 @@ function validateStep(step: number, form: LeadFormData): LeadFormErrors {
       errs.dateOfBirth = "You must be at least 18 years old to submit this form.";
     }
     if (!form.state) errs.state = "Please select your state.";
-    if (!form.coverageInterest) errs.coverageInterest = "Please select a coverage interest.";
+    if (!form.coverageInterest) errs.coverageInterest = "Please select what changed in your life.";
     if (!form.purchaseIntent) errs.purchaseIntent = "Please select your level of interest.";
     if (!form.veteranStatus) errs.veteranStatus = "Please select your background.";
     // Branch is required ONLY for service-connected statuses. Family-members
@@ -231,6 +234,7 @@ function clearFormDraft(): void {
 const INITIAL_FORM: LeadFormData = {
   firstName: "", lastName: "", dateOfBirth: "", email: "", phone: "",
   state: "", coverageInterest: "", purchaseIntent: "", veteranStatus: "", militaryBranch: "",
+  ageRange: "", preferredContactTime: "", message: "",
   tcpaConsent: false, privacyConsent: false, _hp_website: "",
 };
 
@@ -337,6 +341,9 @@ export function useLeadForm(utmParams?: Record<string, string | null>): UseLeadF
             && data.veteranStatus !== "non-military"
             && data.veteranStatus !== "civilian"
             ? data.militaryBranch : "",
+          ageRange: sanitizeInput(data.ageRange),
+          preferredContactTime: sanitizeInput(data.preferredContactTime),
+          message: sanitizeInput(data.message),
           tcpaConsent: data.tcpaConsent,
           privacyConsent: data.privacyConsent,
           consentTimestamp: new Date().toISOString(),
@@ -394,7 +401,7 @@ export function useLeadForm(utmParams?: Record<string, string | null>): UseLeadF
       }
       // Scroll to the first invalid field after React renders
       requestAnimationFrame(() => {
-        const firstErrorField = errorFields
+        const firstErrorField = [...errorFields]
           .sort((a, b) => FIELD_STEP[a] - FIELD_STEP[b])[0];
         const el = document.getElementById(String(firstErrorField));
         if (el) {

--- a/digital-cathedral/app/resources/page.tsx
+++ b/digital-cathedral/app/resources/page.tsx
@@ -1,95 +1,164 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getAllLandingPages } from "../lib/landing-pages";
 import { ServiceSchema } from "../components/schema-markup";
+import { GUIDE_CATEGORIES, getGuidesByCategory } from "../guides/data";
+import { getAllLandingPages } from "../lib/landing-pages";
 
 export const metadata: Metadata = {
-  title: "Military Life Insurance Resources",
+  title: "Helpful Guides for Life’s Biggest Moments",
   description:
-    "Explore life insurance options for veterans, active duty, National Guard, and military families. Free coverage reviews from licensed professionals.",
+    "Explore consumer-friendly life insurance guides for new parents, homeowners, work benefits, final expense planning, retirement, legacy planning, and veteran families.",
   keywords: [
-    "veteran life insurance",
-    "military life insurance",
-    "SGLI alternatives",
-    "military family coverage",
-    "veteran insurance options",
+    "life insurance guides",
+    "new parent life insurance",
+    "homeowner protection",
+    "employer life insurance",
+    "final expense planning",
+    "veteran life insurance benefits",
   ],
   openGraph: {
-    title: "Military Life Insurance Resources",
-    description: "Explore life insurance options for veterans, active duty, National Guard, and military families.",
-    type: "article",
-    modifiedTime: "2026-03-12T00:00:00Z",
+    title: "Helpful Guides for Life’s Biggest Moments",
+    description:
+      "Consumer-friendly Valor Legacies guides for life insurance decisions around family, home, work benefits, retirement, final expenses, and veteran benefits.",
+    type: "website",
   },
 };
 
+const CATEGORY_DESCRIPTIONS: Record<string, string> = {
+  "New Parents":
+    "Protection questions that often come up after welcoming a baby.",
+  Homeowners: "Guidance for protecting the home and the people who live there.",
+  "Work Benefits":
+    "Plain-English help comparing employer coverage with personally owned protection.",
+  "Final Expense":
+    "Calm planning resources for funeral, cremation, burial, and final costs.",
+  "Retirement & Legacy":
+    "Careful education for retirement, legacy, and coverage amount conversations.",
+  "Veterans & Military Families":
+    "Military and veteran benefit resources, plus private coverage considerations.",
+};
+
 export default function ResourcesIndex() {
-  const pages = getAllLandingPages();
+  const veteranResources = getAllLandingPages();
 
   return (
-    <main className="min-h-screen flex flex-col items-center px-4 py-12">
+    <main className="min-h-screen bg-[#fbf7f0] px-4 py-12 text-[#241d15] md:px-8 md:py-16">
       <ServiceSchema />
 
-      <article className="w-full max-w-4xl space-y-8">
-        <header>
+      <article className="mx-auto max-w-7xl space-y-12">
+        <header className="rounded-[2rem] bg-[#241d15] p-8 text-white shadow-[0_24px_80px_rgba(36,29,21,0.18)] md:p-12">
           <Link
             href="/"
-            className="text-teal-cathedral text-xs tracking-[0.2em] uppercase mb-6 inline-block hover:opacity-80 transition-opacity"
+            className="mb-8 inline-flex text-xs font-semibold uppercase tracking-[0.24em] text-[#d6b35f] transition-opacity hover:opacity-80"
           >
             &larr; Back Home
           </Link>
-          <h1 className="text-2xl sm:text-3xl font-light text-[var(--text-primary)] mb-2">
-            Military Life Insurance Resources
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[#d6b35f]">
+            Resource Center
+          </p>
+          <h1 className="mt-4 max-w-4xl font-serif text-4xl font-light leading-tight md:text-6xl">
+            Helpful Guides for Life’s Biggest Moments
           </h1>
-          <p className="text-sm text-[var(--text-muted)] max-w-2xl">
-            Explore coverage options tailored to your military service. Each guide includes
-            FAQs, coverage details, and a free review from licensed professionals who
-            specialize in military-family insurance.
+          <p className="mt-6 max-w-3xl text-lg leading-8 text-[#eadcc7]">
+            Start with the moment that brought you here. These guides are
+            written for families, not insurance insiders, and each one points to
+            reliable references for deeper reading.
           </p>
         </header>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {pages.map((page) => (
-            <Link
-              key={page.slug}
-              href={`/resources/${page.slug}`}
-              className="cathedral-surface p-6 hover:border-teal-cathedral/30 transition-all group"
-            >
-              <h2 className="text-base font-medium text-[var(--text-primary)] group-hover:text-teal-cathedral transition-colors mb-2">
-                {page.title}
-              </h2>
-              <p className="text-sm text-[var(--text-muted)] leading-relaxed">
-                {page.metaDescription}
-              </p>
-              <span className="inline-block mt-3 text-xs text-teal-cathedral">
-                Learn more &rarr;
-              </span>
-            </Link>
-          ))}
+        <div className="space-y-12">
+          {GUIDE_CATEGORIES.map((category) => {
+            const guides = getGuidesByCategory(category);
+            return (
+              <section
+                key={category}
+                className="space-y-5"
+                aria-labelledby={`${category.toLowerCase().replaceAll(" ", "-").replaceAll("&", "and")}-heading`}
+              >
+                <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[#9f782f]">
+                      {category}
+                    </p>
+                    <h2
+                      id={`${category.toLowerCase().replaceAll(" ", "-").replaceAll("&", "and")}-heading`}
+                      className="mt-2 font-serif text-3xl font-light text-[#241d15] md:text-4xl"
+                    >
+                      {category}
+                    </h2>
+                  </div>
+                  <p className="max-w-2xl text-sm leading-6 text-[#6a5c4b]">
+                    {CATEGORY_DESCRIPTIONS[category]}
+                  </p>
+                </div>
+
+                <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+                  {guides.map((guide) => (
+                    <Link
+                      key={guide.slug}
+                      href={`/guides/${guide.slug}`}
+                      className="group rounded-[1.5rem] bg-white p-6 shadow-[0_18px_60px_rgba(61,43,24,0.08)] transition-all hover:-translate-y-1 hover:shadow-[0_24px_70px_rgba(61,43,24,0.14)]"
+                    >
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#9f782f]">
+                        Guide
+                      </p>
+                      <h3 className="mt-3 text-xl font-semibold text-[#241d15] transition-colors group-hover:text-[#9f782f]">
+                        {guide.title}
+                      </h3>
+                      <p className="mt-3 text-sm leading-6 text-[#6a5c4b]">
+                        {guide.purpose}
+                      </p>
+                      <span className="mt-5 inline-flex text-sm font-semibold text-[#9f782f]">
+                        Read Guide &rarr;
+                      </span>
+                    </Link>
+                  ))}
+
+                  {category === "Veterans & Military Families" &&
+                    veteranResources.map((page) => (
+                      <Link
+                        key={page.slug}
+                        href={`/resources/${page.slug}`}
+                        className="group rounded-[1.5rem] border border-[#decda9] bg-white/75 p-6 transition-all hover:-translate-y-1 hover:border-[#d6b35f]"
+                      >
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#9f782f]">
+                          Veteran resource
+                        </p>
+                        <h3 className="mt-3 text-xl font-semibold text-[#241d15] transition-colors group-hover:text-[#9f782f]">
+                          {page.title}
+                        </h3>
+                        <p className="mt-3 text-sm leading-6 text-[#6a5c4b]">
+                          {page.metaDescription}
+                        </p>
+                        <span className="mt-5 inline-flex text-sm font-semibold text-[#9f782f]">
+                          Read Resource &rarr;
+                        </span>
+                      </Link>
+                    ))}
+                </div>
+              </section>
+            );
+          })}
         </div>
 
-        <div className="text-center pt-8">
+        <section className="rounded-[2rem] bg-[#241d15] p-8 text-center text-white md:p-10">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[#d6b35f]">
+            Not sure where to start?
+          </p>
+          <h2 className="mt-3 font-serif text-3xl font-light">
+            Tell us what changed in your life.
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-7 text-[#eadcc7]">
+            The protection path starts with your life chapter, then helps guide
+            the next conversation.
+          </p>
           <Link
-            href="/"
-            className="inline-block px-8 py-3 rounded-lg font-medium text-sm transition-all bg-teal-cathedral text-white hover:bg-teal-cathedral/90"
+            href="/#protection-path"
+            className="mt-7 inline-flex rounded-full bg-[#d6b35f] px-8 py-3 text-sm font-semibold text-[#241d15] transition-transform hover:-translate-y-0.5"
           >
-            Start My Free Coverage Review
+            Start My Protection Path
           </Link>
-          <p className="text-xs text-[var(--text-muted)] mt-2">
-            Takes less than 60 seconds. No obligation.
-          </p>
-        </div>
-
-        <footer className="pt-8 border-t border-teal-cathedral/10 text-center">
-          <nav className="flex gap-4 justify-center mb-3">
-            <Link href="/blog" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Blog</Link>
-            <Link href="/faq" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">FAQ</Link>
-            <Link href="/about" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">About</Link>
-            <Link href="/privacy" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Privacy</Link>
-          </nav>
-          <p className="text-xs text-[var(--text-muted)]">
-            &copy; {new Date().getFullYear()} Valor Legacies. All rights reserved.
-          </p>
-        </footer>
+        </section>
       </article>
     </main>
   );

--- a/digital-cathedral/app/sitemap.ts
+++ b/digital-cathedral/app/sitemap.ts
@@ -1,11 +1,21 @@
 import type { MetadataRoute } from "next";
 import { headers } from "next/headers";
 import { getAllPosts } from "./lib/blog-posts";
+import { GUIDES } from "./guides/data";
 import { getAllLandingPages } from "./lib/landing-pages";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const leadsBaseUrl = (process.env.NEXT_PUBLIC_SITE_URL || "https://valorlegacies.com").split(",")[0].trim();
-  const portalDomain = (process.env.PORTAL_DOMAIN || "").trim().toLowerCase();
+  const leadsBaseUrl = (
+    process.env.NEXT_PUBLIC_SITE_URL || "https://valorlegacies.com"
+  )
+    .split(",")[0]
+    .trim();
+  const primaryDomain = (process.env.PRIMARY_DOMAIN || "valorlegacies.com")
+    .trim()
+    .toLowerCase();
+  const portalDomain =
+    (process.env.PORTAL_DOMAIN || "").trim().toLowerCase() ||
+    (primaryDomain.endsWith(".com") ? `${primaryDomain.slice(0, -4)}.xyz` : "");
 
   // Detect current domain to serve the right sitemap
   let isPortal = false;
@@ -21,130 +31,135 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getAllPosts();
   const resources = getAllLandingPages();
 
-  const staticRoutes: MetadataRoute.Sitemap = [
-    {
-      url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/about`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/how-we-score`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/developers/agents`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/faq`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/blog`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/privacy`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${baseUrl}/terms`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    // Landing pages
-    {
-      url: `${baseUrl}/lp/veteran-life-insurance`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/lp/military-family`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.8,
-    },
-    // AI agent discovery endpoints
-    {
-      url: `${baseUrl}/llms.txt`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/api/agent/schema`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/.well-known/mcp.json`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/feed.json`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.5,
-    },
-    {
-      url: `${baseUrl}/feed.xml`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.5,
-    },
-    {
-      url: `${baseUrl}/developers`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-  ];
+  const staticRoutes: MetadataRoute.Sitemap = isPortal
+    ? [
+        {
+          url: `${baseUrl}/portal`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.7,
+        },
+        {
+          url: `${baseUrl}/portal/marketplace`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.7,
+        },
+        {
+          url: `${baseUrl}/portal/privacy`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.4,
+        },
+        {
+          url: `${baseUrl}/portal/terms`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.4,
+        },
+      ]
+    : [
+        {
+          url: baseUrl,
+          lastModified: new Date(),
+          changeFrequency: "weekly",
+          priority: 1,
+        },
+        {
+          url: `${baseUrl}/about`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.7,
+        },
+        {
+          url: `${baseUrl}/faq`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.8,
+        },
+        {
+          url: `${baseUrl}/blog`,
+          lastModified: new Date(),
+          changeFrequency: "weekly",
+          priority: 0.9,
+        },
+        {
+          url: `${baseUrl}/privacy`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.5,
+        },
+        {
+          url: `${baseUrl}/terms`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.5,
+        },
+        {
+          url: `${baseUrl}/lp/veteran-life-insurance`,
+          lastModified: new Date(),
+          changeFrequency: "weekly",
+          priority: 0.8,
+        },
+        {
+          url: `${baseUrl}/lp/military-family`,
+          lastModified: new Date(),
+          changeFrequency: "weekly",
+          priority: 0.8,
+        },
+        {
+          url: `${baseUrl}/feed.json`,
+          lastModified: new Date(),
+          changeFrequency: "weekly",
+          priority: 0.5,
+        },
+        {
+          url: `${baseUrl}/feed.xml`,
+          lastModified: new Date(),
+          changeFrequency: "weekly",
+          priority: 0.5,
+        },
+      ];
 
   // Dynamic blog post routes
-  const blogRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
-    url: `${baseUrl}/blog/${post.slug}`,
-    lastModified: new Date(post.dateModified || post.datePublished),
-    changeFrequency: "monthly" as const,
-    priority: 0.7,
-  }));
+  const blogRoutes: MetadataRoute.Sitemap = isPortal
+    ? []
+    : posts.map((post) => ({
+        url: `${baseUrl}/blog/${post.slug}`,
+        lastModified: new Date(post.dateModified || post.datePublished),
+        changeFrequency: "monthly" as const,
+        priority: 0.7,
+      }));
 
   // Dynamic resource/landing page routes
-  const resourceRoutes: MetadataRoute.Sitemap = [
-    {
-      url: `${baseUrl}/resources`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.8,
-    },
-    ...resources.map((page) => ({
-      url: `${baseUrl}/resources/${page.slug}`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.7,
-    })),
-  ];
+  const resourceRoutes: MetadataRoute.Sitemap = isPortal
+    ? []
+    : [
+        {
+          url: `${baseUrl}/resources`,
+          lastModified: new Date(),
+          changeFrequency: "weekly" as const,
+          priority: 0.8,
+        },
+        {
+          url: `${baseUrl}/guides`,
+          lastModified: new Date(),
+          changeFrequency: "weekly" as const,
+          priority: 0.6,
+        },
+        ...GUIDES.map((guide) => ({
+          url: `${baseUrl}/guides/${guide.slug}`,
+          lastModified: new Date(),
+          changeFrequency: "monthly" as const,
+          priority: 0.75,
+        })),
+        ...resources.map((page) => ({
+          url: `${baseUrl}/resources/${page.slug}`,
+          lastModified: new Date(),
+          changeFrequency: "monthly" as const,
+          priority: 0.7,
+        })),
+      ];
 
   return [...staticRoutes, ...blogRoutes, ...resourceRoutes];
 }

--- a/digital-cathedral/middleware.ts
+++ b/digital-cathedral/middleware.ts
@@ -24,27 +24,30 @@ const ADMIN_SESSION_COOKIE = "__admin_session";
 // ─── Multi-Domain Configuration ───
 //
 // Architecture:
-//   PRIMARY     www.valorlegacies.com — canonical home; receives most traffic;
-//               serves marketing + lead capture + login + portal/admin.
-//   VIRAL       *.xyz domains — viral-lattice entry points. Every inbound
-//               request, no matter what path was clicked, redirects to the
-//               primary home so the visitor must log in (become a lead)
-//               before reaching anything else. After login they land on the
-//               primary main page.
+//   PRIMARY     www.valorlegacies.com — canonical consumer site for families,
+//               guides, lead capture, privacy/legal, and brand storytelling.
+//   PORTAL      www.valorlegacies.xyz — operational agent/admin/developer host
+//               for portals, lead purchasing, API docs, and internal surfaces.
+//   VIRAL       non-canonical *.xyz domains — viral-lattice entry points that
+//               funnel public visitors back to the primary consumer home.
 //   LEADS       additional marketing TLDs (.net/.info/.store/.shop) — serve
 //               the same public site as the primary; portal-only paths bounce
-//               to the primary.
+//               to the portal host.
 //
 // Anything not matched above is treated as VIRAL (catch-all funnel) so any
 // new lattice domain you point at the deployment auto-routes into the funnel
 // without code changes.
-const PRIMARY_DOMAIN: string =
-  (process.env.PRIMARY_DOMAIN ?? "valorlegacies.com").trim().toLowerCase();
-const PRIMARY_BASE_URL: string =
-  (process.env.NEXT_PUBLIC_SITE_URL ?? `https://www.${PRIMARY_DOMAIN}`)
-    .split(",")[0]
-    .trim()
-    .replace(/\/$/, "");
+const PRIMARY_DOMAIN: string = (
+  process.env.PRIMARY_DOMAIN ?? "valorlegacies.com"
+)
+  .trim()
+  .toLowerCase();
+const PRIMARY_BASE_URL: string = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? `https://www.${PRIMARY_DOMAIN}`
+)
+  .split(",")[0]
+  .trim()
+  .replace(/\/$/, "");
 const LEADS_DOMAINS: string[] = (process.env.LEADS_DOMAINS ?? "")
   .split(",")
   .map((d) => d.trim().toLowerCase())
@@ -54,7 +57,9 @@ const LEADS_DOMAINS: string[] = (process.env.LEADS_DOMAINS ?? "")
  * LEADS lists is treated as viral by default. List them here only when you
  * want a name that wouldn't otherwise be recognized (e.g. a non-.xyz TLD).
  */
-const VIRAL_LATTICE_DOMAINS: string[] = (process.env.VIRAL_LATTICE_DOMAINS ?? "")
+const VIRAL_LATTICE_DOMAINS: string[] = (
+  process.env.VIRAL_LATTICE_DOMAINS ?? ""
+)
   .split(",")
   .map((d) => d.trim().toLowerCase())
   .filter(Boolean);
@@ -64,18 +69,21 @@ const VIRAL_LATTICE_DOMAINS: string[] = (process.env.VIRAL_LATTICE_DOMAINS ?? ""
 // default, an unset PORTAL_DOMAIN lets the .xyz catch-all in getDomainType
 // classify the portal host as "viral" and redirect admin/portal traffic to
 // the lead form on .com — exactly the bug the operator hit in production.
-const PORTAL_DOMAIN: string = ((process.env.PORTAL_DOMAIN ?? "").trim().toLowerCase())
-  || (PRIMARY_DOMAIN.endsWith(".com")
-    ? `${PRIMARY_DOMAIN.slice(0, -4)}.xyz`
-    : "");
+const PORTAL_DOMAIN: string =
+  (process.env.PORTAL_DOMAIN ?? "").trim().toLowerCase() ||
+  (PRIMARY_DOMAIN.endsWith(".com") ? `${PRIMARY_DOMAIN.slice(0, -4)}.xyz` : "");
 /** Canonical portal URL with protocol + www, used for redirects from leads domains. */
-const PORTAL_BASE_URL: string = ((process.env.NEXT_PUBLIC_PORTAL_URL ?? "").trim().replace(/\/$/, ""))
-  || (PORTAL_DOMAIN ? `https://www.${PORTAL_DOMAIN}` : "");
+const PORTAL_BASE_URL: string =
+  (process.env.NEXT_PUBLIC_PORTAL_URL ?? "").trim().replace(/\/$/, "") ||
+  (PORTAL_DOMAIN ? `https://www.${PORTAL_DOMAIN}` : "");
 
 type DomainType = "primary" | "leads" | "portal" | "viral" | "unknown";
 
 function stripHost(hostname: string): string {
-  return hostname.toLowerCase().split(":")[0].replace(/^www\./, "");
+  return hostname
+    .toLowerCase()
+    .split(":")[0]
+    .replace(/^www\./, "");
 }
 
 function getDomainType(hostname: string): DomainType {
@@ -96,26 +104,61 @@ function getDomainType(hostname: string): DomainType {
   return "unknown";
 }
 
+/** Consumer-visible technical/operator pages that belong on the .xyz portal. */
+const CONSUMER_TO_PORTAL_REDIRECTS: Record<string, string> = {
+  "/admin": "/admin",
+  "/agent": "/portal",
+  "/agent-login": "/portal/login",
+  "/developers": "/developers",
+  "/api-docs": "/developers",
+  "/ai-agent": "/developers",
+  "/portal": "/portal",
+};
+
 /** Routes that must only be served on the portal domain. */
-const PORTAL_ONLY_PREFIXES = ["/admin", "/portal", "/api/admin", "/api/client", "/api/portal"];
+const PORTAL_ONLY_PREFIXES = [
+  "/admin",
+  "/portal",
+  "/developers",
+  "/api/admin",
+  "/api/client",
+  "/api/portal",
+];
+
+function getPortalRedirectPath(pathname: string): string | null {
+  const match = Object.keys(CONSUMER_TO_PORTAL_REDIRECTS)
+    .sort((a, b) => b.length - a.length)
+    .find((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+  if (!match) return null;
+  return `${CONSUMER_TO_PORTAL_REDIRECTS[match]}${pathname.slice(match.length)}`;
+}
+
+function redirectToPortal(request: NextRequest, path: string): NextResponse {
+  const base =
+    PORTAL_BASE_URL ||
+    (PORTAL_DOMAIN ? `https://www.${PORTAL_DOMAIN}` : PRIMARY_BASE_URL);
+  const portalUrl = new URL(path, base);
+  portalUrl.search = request.nextUrl.search;
+  return NextResponse.redirect(portalUrl.toString(), 301);
+}
 
 // ─── AI Crawler Detection ───
 // Known AI crawler user-agent patterns for telemetry
 const AI_CRAWLERS: Record<string, string> = {
-  "GPTBot": "OpenAI",
+  GPTBot: "OpenAI",
   "ChatGPT-User": "OpenAI",
-  "ClaudeBot": "Anthropic",
+  ClaudeBot: "Anthropic",
   "Claude-Web": "Anthropic",
   "Google-Extended": "Google",
-  "Googlebot": "Google",
-  "PerplexityBot": "Perplexity",
-  "Amazonbot": "Amazon",
+  Googlebot: "Google",
+  PerplexityBot: "Perplexity",
+  Amazonbot: "Amazon",
   "cohere-ai": "Cohere",
-  "YouBot": "You.com",
-  "CCBot": "Common Crawl",
-  "Bytespider": "ByteDance",
+  YouBot: "You.com",
+  CCBot: "Common Crawl",
+  Bytespider: "ByteDance",
   "Meta-ExternalAgent": "Meta",
-  "FacebookBot": "Meta",
+  FacebookBot: "Meta",
 };
 
 /**
@@ -168,8 +211,14 @@ async function hasAdminSession(request: NextRequest): Promise<boolean> {
   const sessionCookie = request.cookies.get(ADMIN_SESSION_COOKIE)?.value;
   if (sessionCookie && isSessionLikelyValid(sessionCookie)) return true;
   try {
-    const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
-    if (token?.email && ADMIN_EMAILS.includes((token.email as string).toLowerCase())) {
+    const token = await getToken({
+      req: request,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+    if (
+      token?.email &&
+      ADMIN_EMAILS.includes((token.email as string).toLowerCase())
+    ) {
       return true;
     }
   } catch {
@@ -222,14 +271,13 @@ export async function middleware(request: NextRequest) {
   }
 
   if (domainType === "leads") {
-    const isPortalRoute = PORTAL_ONLY_PREFIXES.some((p) => pathname.startsWith(p));
+    const isPortalRoute = PORTAL_ONLY_PREFIXES.some((p) =>
+      pathname.startsWith(p),
+    );
     if (isPortalRoute) {
       // If the portal domain is configured, redirect there; otherwise return 404
       if (PORTAL_BASE_URL || PORTAL_DOMAIN) {
-        const base = PORTAL_BASE_URL || `https://${PORTAL_DOMAIN}`;
-        const portalUrl = new URL(pathname, base);
-        portalUrl.search = request.nextUrl.search;
-        return NextResponse.redirect(portalUrl.toString(), 301);
+        return redirectToPortal(request, pathname);
       }
       return NextResponse.json(
         { error: "This route is not available on this domain." },
@@ -244,13 +292,19 @@ export async function middleware(request: NextRequest) {
     // the operator surface is the default landing on the operator host.
     // Buyers still reach the marketplace via explicit /portal/* URLs.
     const isPortalRoute =
+      pathname === "/" ||
       pathname === "/portal" ||
       pathname.startsWith("/portal/") ||
       pathname.startsWith("/admin") ||
+      pathname.startsWith("/developers") ||
       pathname.startsWith("/api/") ||
       pathname.startsWith("/_next") ||
       pathname.startsWith("/.well-known") ||
       pathname.includes(".");
+    if (pathname === "/" && !(await hasAdminSession(request))) {
+      const portalHome = new URL("/portal", request.url);
+      return NextResponse.redirect(portalHome, 301);
+    }
     // A logged-in admin can roam the full public site on the portal host
     // (About, FAQ, the marketing home, etc.) instead of being bounced to
     // /admin — "navigate the full website as admin". Everyone else is sent to
@@ -268,17 +322,16 @@ export async function middleware(request: NextRequest) {
   // the portal so the two surfaces stay fully separated. The lead form on
   // /.com keeps its identity; the operator never visually leaks into it.
   if (domainType === "primary") {
-    const isOperatorSurface =
-      pathname.startsWith("/admin") ||
-      pathname.startsWith("/portal") ||
+    const portalRedirectPath = getPortalRedirectPath(pathname);
+    const isOperatorApi =
       pathname.startsWith("/api/admin") ||
       pathname.startsWith("/api/portal") ||
       pathname.startsWith("/api/client");
-    if (isOperatorSurface && (PORTAL_BASE_URL || PORTAL_DOMAIN)) {
-      const base = PORTAL_BASE_URL || `https://www.${PORTAL_DOMAIN}`;
-      const portalUrl = new URL(pathname, base);
-      portalUrl.search = request.nextUrl.search;
-      return NextResponse.redirect(portalUrl.toString(), 301);
+    if (
+      (portalRedirectPath || isOperatorApi) &&
+      (PORTAL_BASE_URL || PORTAL_DOMAIN)
+    ) {
+      return redirectToPortal(request, portalRedirectPath || pathname);
     }
   }
 
@@ -329,7 +382,9 @@ export async function middleware(request: NextRequest) {
         org: crawler.org,
         path: pathname,
         timestamp: new Date().toISOString(),
-        ip: request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown",
+        ip:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          "unknown",
       }),
     );
   }
@@ -342,12 +397,17 @@ export async function middleware(request: NextRequest) {
     !pathname.startsWith("/api") &&
     !pathname.startsWith("/admin") &&
     !pathname.startsWith("/portal") &&
+    !pathname.startsWith("/developers") &&
     !pathname.startsWith("/_next") &&
     !pathname.startsWith("/.well-known") &&
     !pathname.includes(".");
 
   if (crawler && isPublicPage && accept.includes("application/json")) {
-    const baseUrl = (process.env.NEXT_PUBLIC_SITE_URL || "https://valorlegacies.com").split(",")[0].trim();
+    const baseUrl = (
+      process.env.NEXT_PUBLIC_SITE_URL || "https://valorlegacies.com"
+    )
+      .split(",")[0]
+      .trim();
 
     // Page-specific structured data for known routes — AEO-enriched with quotable answers
     const pageData: Record<string, object> = {
@@ -356,13 +416,17 @@ export async function middleware(request: NextRequest) {
         "@type": "WebSite",
         name: "Valor Legacies",
         url: baseUrl,
-        description: "Valor Legacies is a veteran-founded platform that connects active duty service members, veterans, National Guard, Reserve, and military families with licensed life insurance professionals. Free, no-obligation coverage reviews. Not an insurance company — a service that matches you with the right licensed professional.",
+        description:
+          "Valor Legacies is a veteran-founded platform that connects active duty service members, veterans, National Guard, Reserve, and military families with licensed life insurance professionals. Free, no-obligation coverage reviews. Not an insurance company — a service that matches you with the right licensed professional.",
         potentialAction: {
           "@type": "SearchAction",
           target: `${baseUrl}/faq?q={search_term_string}`,
           "query-input": "required name=search_term_string",
         },
-        founder: { "@type": "Person", description: "Veteran-founded and operated" },
+        founder: {
+          "@type": "Person",
+          description: "Veteran-founded and operated",
+        },
         areaServed: { "@type": "Country", name: "United States" },
       },
       "/about": {
@@ -370,20 +434,57 @@ export async function middleware(request: NextRequest) {
         "@type": "AboutPage",
         name: "About Valor Legacies",
         url: `${baseUrl}/about`,
-        description: "Valor Legacies is a veteran-founded, independently operated platform. It is not affiliated with the U.S. Government, Department of Defense, or any military branch. The platform connects military families with licensed life insurance professionals for free, no-obligation coverage reviews across all 50 states, D.C., and Puerto Rico.",
+        description:
+          "Valor Legacies is a veteran-founded, independently operated platform. It is not affiliated with the U.S. Government, Department of Defense, or any military branch. The platform connects military families with licensed life insurance professionals for free, no-obligation coverage reviews across all 50 states, D.C., and Puerto Rico.",
       },
       "/faq": {
         "@context": "https://schema.org",
         "@type": "FAQPage",
         name: "Frequently Asked Questions",
         url: `${baseUrl}/faq`,
-        description: "Common questions about Valor Legacies, military life insurance options, SGLI, VGLI, VA programs, and AI agent consent.",
+        description:
+          "Common questions about Valor Legacies, military life insurance options, SGLI, VGLI, VA programs, and AI agent consent.",
         mainEntity: [
-          { "@type": "Question", name: "What is the best life insurance for veterans?", acceptedAnswer: { "@type": "Answer", text: "The best life insurance for veterans depends on individual needs. Term life is ideal for mortgage protection and income replacement. Whole life suits final expense and legacy planning. Indexed Universal Life (IUL) combines retirement savings with life insurance. Veterans should compare VGLI rates with private market options." } },
-          { "@type": "Question", name: "What happens to SGLI when you leave the military?", acceptedAnswer: { "@type": "Answer", text: "SGLI coverage continues for 120 days after separation at no cost. Veterans then have 240 days total to convert to VGLI without a medical exam. After that window, conversion requires proof of good health. Many veterans find private term policies more cost-effective than VGLI long-term." } },
-          { "@type": "Question", name: "Can disabled veterans get life insurance?", acceptedAnswer: { "@type": "Answer", text: "Yes. The VA offers Service-Disabled Veterans Life Insurance (S-DVI) and VALife, providing up to $40,000 in whole life coverage with guaranteed acceptance for any service-connected disability rating. Private guaranteed-issue policies are also available." } },
-          { "@type": "Question", name: "How much life insurance does a military family need?", acceptedAnswer: { "@type": "Answer", text: "Financial advisors recommend 10-12 times annual income, including BAH, base pay, and special pay. SGLI covers up to $500,000, but families with mortgages, children, or a single-income household typically need additional coverage." } },
-          { "@type": "Question", name: "Does Valor Legacies sell insurance?", acceptedAnswer: { "@type": "Answer", text: "No. Valor Legacies does not sell insurance, provide quotes, or bind coverage. It connects consumers with licensed insurance professionals. The consultation is free with no obligation." } },
+          {
+            "@type": "Question",
+            name: "What is the best life insurance for veterans?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "The best life insurance for veterans depends on individual needs. Term life is ideal for mortgage protection and income replacement. Whole life suits final expense and legacy planning. Indexed Universal Life (IUL) combines retirement savings with life insurance. Veterans should compare VGLI rates with private market options.",
+            },
+          },
+          {
+            "@type": "Question",
+            name: "What happens to SGLI when you leave the military?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "SGLI coverage continues for 120 days after separation at no cost. Veterans then have 240 days total to convert to VGLI without a medical exam. After that window, conversion requires proof of good health. Many veterans find private term policies more cost-effective than VGLI long-term.",
+            },
+          },
+          {
+            "@type": "Question",
+            name: "Can disabled veterans get life insurance?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "Yes. The VA offers Service-Disabled Veterans Life Insurance (S-DVI) and VALife, providing up to $40,000 in whole life coverage with guaranteed acceptance for any service-connected disability rating. Private guaranteed-issue policies are also available.",
+            },
+          },
+          {
+            "@type": "Question",
+            name: "How much life insurance does a military family need?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "Financial advisors recommend 10-12 times annual income, including BAH, base pay, and special pay. SGLI covers up to $500,000, but families with mortgages, children, or a single-income household typically need additional coverage.",
+            },
+          },
+          {
+            "@type": "Question",
+            name: "Does Valor Legacies sell insurance?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "No. Valor Legacies does not sell insurance, provide quotes, or bind coverage. It connects consumers with licensed insurance professionals. The consultation is free with no obligation.",
+            },
+          },
         ],
       },
       "/blog": {
@@ -391,34 +492,16 @@ export async function middleware(request: NextRequest) {
         "@type": "CollectionPage",
         name: "Veteran Life Insurance Resources — Blog",
         url: `${baseUrl}/blog`,
-        description: "Expert guides on SGLI, VGLI, VA insurance programs, and private coverage options for service members, veterans, and military families. Published by Valor Legacies.",
+        description:
+          "Expert guides on SGLI, VGLI, VA insurance programs, and private coverage options for service members, veterans, and military families. Published by Valor Legacies.",
       },
       "/resources": {
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         name: "Military Life Insurance Resources",
         url: `${baseUrl}/resources`,
-        description: "Explore life insurance options for veterans, active duty, National Guard, and military families. Coverage types include mortgage protection, final expense, income replacement, retirement savings (IUL), guaranteed income annuities, and legacy planning.",
-      },
-      "/developers": {
-        "@context": "https://schema.org",
-        "@type": "WebPage",
-        name: "Valor Legacies — AI Agent Developer Portal",
-        url: `${baseUrl}/developers`,
-        description: "Integrate your AI agent with Valor Legacies. OpenAPI 3.1 schema, MCP protocol support, consent-based lead submission API. Free API access for authorized AI agents. Supports ChatGPT, Claude, Gemini, Perplexity, and custom agents.",
-        mainEntity: {
-          "@type": "SoftwareApplication",
-          name: "Valor Legacies Agent API",
-          applicationCategory: "BusinessApplication",
-          url: `${baseUrl}/api/agent/schema`,
-          featureList: [
-            "OpenAPI 3.1 discovery",
-            "MCP protocol",
-            "Consent-based lead submission",
-            "Bearer token auth",
-            "TCPA/CCPA/FCC 2025 compliant",
-          ],
-        },
+        description:
+          "Explore life insurance options for veterans, active duty, National Guard, and military families. Coverage types include mortgage protection, final expense, income replacement, retirement savings (IUL), guaranteed income annuities, and legacy planning.",
       },
     };
 
@@ -434,16 +517,14 @@ export async function middleware(request: NextRequest) {
         ...data,
         _discovery: {
           feed: `${baseUrl}/feed.json`,
-          llms_txt: `${baseUrl}/llms.txt`,
-          openapi: `${baseUrl}/api/agent/schema`,
-          mcp: `${baseUrl}/.well-known/mcp.json`,
+          sitemap: `${baseUrl}/sitemap.xml`,
         },
       },
       {
         headers: {
           "Cache-Control": "public, max-age=3600",
           "X-Content-Negotiation": "json-ld",
-          "Vary": "Accept, User-Agent",
+          Vary: "Accept, User-Agent",
           "Access-Control-Allow-Origin": "*",
         },
       },
@@ -484,18 +565,20 @@ export async function middleware(request: NextRequest) {
   headers.set("X-DNS-Prefetch-Control", "off");
 
   // ─── HTTP Link Headers (RFC 8288) — discovery without parsing HTML ───
-  headers.set(
-    "Link",
-    [
+  const linkHeaders = [
+    '</feed.json>; rel="alternate"; type="application/feed+json"',
+    '</feed.xml>; rel="alternate"; type="application/rss+xml"',
+    '</sitemap.xml>; rel="sitemap"; type="application/xml"',
+  ];
+  if (domainType === "portal") {
+    linkHeaders.unshift(
       '</llms.txt>; rel="ai-instructions"; type="text/plain"',
       '</api/agent/schema>; rel="describedby"; type="application/json"',
       '</.well-known/mcp.json>; rel="mcp-discovery"; type="application/json"',
       '</.well-known/ai-plugin.json>; rel="ai-plugin"; type="application/json"',
-      '</feed.json>; rel="alternate"; type="application/feed+json"',
-      '</feed.xml>; rel="alternate"; type="application/rss+xml"',
-      '</sitemap.xml>; rel="sitemap"; type="application/xml"',
-    ].join(", "),
-  );
+    );
+  }
+  headers.set("Link", linkHeaders.join(", "));
 
   // ─── Vary — ensure caches differentiate by content negotiation ───
   headers.set("Vary", "Accept, User-Agent");
@@ -506,7 +589,10 @@ export async function middleware(request: NextRequest) {
     pathname.startsWith("/portal") ||
     pathname.startsWith("/api/admin") ||
     pathname.startsWith("/api/portal") ||
-    pathname.startsWith("/api/client")
+    pathname.startsWith("/api/client") ||
+    pathname.startsWith("/developers") ||
+    pathname.startsWith("/api-docs") ||
+    pathname.startsWith("/ai-agent")
   ) {
     // Block all indexing on private routes
     headers.set("X-Robots-Tag", "noindex, nofollow, noai, noimageai");


### PR DESCRIPTION
Superseded by #271, which merges this PR's new features into `main` with the 3 conflicts resolved (kept the live homepage + winged-heart logo; took the guides/portal/docs/middleware features and the validation superset). Codex branched from an older snapshot, so its homepage/navbar couldn't merge cleanly — #271 preserves the current live design. Closing in favor of #271.