### PR TITLE
Refine Guides routing and customer-facing copy (homepage, resources, About, FAQ, testimonials)

### DIFF
--- a/digital-cathedral/app/about/page.tsx
+++ b/digital-cathedral/app/about/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "About & Contact",
   description:
-    "Learn about Valor Legacies — veteran-founded life insurance lead generation for military families.",
+    "Meet Andrea Golden and learn why she founded Valor Legacies to make family protection more personal, understandable, and rooted in real life.",
 };
 
 export default function AboutPage() {
@@ -25,14 +25,21 @@ export default function AboutPage() {
 
         <section className="space-y-4 text-sm text-[var(--text-muted)] leading-relaxed">
           <h2 className="text-lg text-[var(--text-primary)] font-medium">
-            Our Mission
+            Andrea Golden’s Founder Story
           </h2>
           <p>
-            Valor Legacies was founded by a veteran with a simple mission: to
-            help military families understand their life insurance options beyond
-            standard military coverage. We connect service members, veterans,
-            and their families with licensed professionals who specialize in
-            protecting military households.
+            Valor Legacies was founded by Andrea Golden, a veteran who believes
+            service means showing up with purpose, protecting others, and doing
+            the right thing even when no one is watching. That same spirit is
+            the foundation of Valor Legacies.
+          </p>
+          <p>
+            Andrea created the company to make life insurance feel personal,
+            understandable, and rooted in real life—not complicated or
+            intimidating. Whether someone has welcomed a baby, bought a home,
+            gotten married, started planning for retirement, or wants to keep a
+            financial burden from falling on family, Valor Legacies helps them
+            take the next step with confidence.
           </p>
           <p>
             &ldquo;Valor&rdquo; represents courage, bravery, and selfless
@@ -44,6 +51,10 @@ export default function AboutPage() {
           <p>
             Together, Valor Legacies stands for honoring a life of courage by
             protecting the future of those you love.
+          </p>
+          <p className="font-medium text-[var(--text-primary)]">
+            For the life you live, and the love you leave, this is why Valor
+            Legacies exists.
           </p>
         </section>
 
@@ -59,6 +70,8 @@ export default function AboutPage() {
               "Military Families",
               "Transitioning Service Members",
               "Military Spouses",
+              "New Parents",
+              "Homeowners & Families",
             ].map((category) => (
               <div
                 key={category}
@@ -80,8 +93,8 @@ export default function AboutPage() {
               sell, quote, or bind insurance coverage.
             </li>
             <li>
-              We operate as an independent lead generation service, connecting
-              military families with licensed insurance professionals.
+              We are an independent life insurance resource and may connect
+              consumers with licensed insurance professionals.
             </li>
             <li>
               We do not provide insurance advice, recommendations, or coverage
@@ -89,8 +102,8 @@ export default function AboutPage() {
             </li>
             <li>
               Valor Legacies is independently operated and is not affiliated
-              with the U.S. Government, Department of Defense, or any branch of
-              the military.
+              with the U.S. Department of Veterans Affairs, the Department of
+              Defense, or any government agency.
             </li>
             <li>
               Coverage availability, rates, and terms vary by state and are
@@ -215,6 +228,12 @@ export default function AboutPage() {
         </section>
 
         <footer className="pt-8 border-t border-teal-cathedral/10 text-center">
+          <nav className="mb-3 flex justify-center gap-4" aria-label="Footer navigation">
+            <Link href="/resources" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Guides</Link>
+            <Link href="/faq" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">FAQ</Link>
+            <Link href="/privacy" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Privacy Policy</Link>
+            <Link href="/terms" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Terms of Service</Link>
+          </nav>
           <p className="text-xs text-[var(--text-muted)]">
             &copy; {new Date().getFullYear()} Valor Legacies. All rights reserved.
           </p>

--- a/digital-cathedral/app/faq/page.tsx
+++ b/digital-cathedral/app/faq/page.tsx
@@ -5,13 +5,17 @@ import { AEOSpeakablePage } from "../components/aeo-schema";
 export const metadata: Metadata = {
   title: "Frequently Asked Questions",
   description:
-    "Common questions about Valor Legacies, military life insurance options, SGLI alternatives, and how our free coverage review works.",
+    "Common questions about Valor Legacies, life insurance for major life moments, and how our no-cost coverage review works.",
 };
 
 const FAQS = [
   {
-    q: "What is the best life insurance for veterans?",
-    a: "The best life insurance for veterans depends on your needs. Term life is ideal for mortgage protection and income replacement. Whole life works well for final expense and legacy planning. Indexed Universal Life (IUL) offers retirement savings with life insurance protection. A licensed professional can help you compare options based on your service history, age, and family situation.",
+    q: "How do I know what kind of life insurance may fit my family?",
+    a: "The right fit depends on the people who rely on you, your budget, health, debts, income, and long-term goals. Term and permanent policies serve different needs. A licensed insurance professional can explain available options and help you compare them without assuming one solution fits everyone.",
+  },
+  {
+    q: "When should I review my life insurance needs?",
+    a: "Major life moments are useful times to review protection: welcoming a child, getting married, buying a home, changing jobs, preparing for retirement, supporting aging relatives, or planning final expenses. You can also request a review simply because your current coverage no longer feels clear.",
   },
   {
     q: "Is this the same as SGLI?",
@@ -19,15 +23,15 @@ const FAQS = [
   },
   {
     q: "Is this affiliated with the military or government?",
-    a: "No. Valor Legacies is independently operated and not affiliated with the U.S. Government, Department of Defense, or any branch of military service.",
+    a: "No. Valor Legacies is independently operated and is not affiliated with the U.S. Department of Veterans Affairs, the Department of Defense, or any government agency.",
   },
   {
     q: "Is there any obligation to purchase?",
     a: "No. Requesting a review simply connects you with a licensed professional to explore your options. There is no obligation, no pressure, and no cost for the consultation.",
   },
   {
-    q: "Are veterans eligible?",
-    a: "Yes. Many life insurance options are available for veterans, including those who have fully separated from service. Options vary by state and individual eligibility.",
+    q: "Who can request a coverage review?",
+    a: "Adults exploring family, income, mortgage, final expense, retirement, or legacy protection may request a review. Valor Legacies also welcomes service members, veterans, and military families. Available options depend on state availability, underwriting, and individual eligibility.",
   },
   {
     q: "How long does the process take?",
@@ -43,11 +47,11 @@ const FAQS = [
   },
   {
     q: "Who will contact me?",
-    a: "A licensed insurance professional experienced in military-family coverage will review your information and reach out via phone or email.",
+    a: "A licensed insurance professional will review your information and may reach out by phone, text, or email using the contact preferences and consent you provide.",
   },
   {
     q: "What types of coverage can I explore?",
-    a: "You can explore mortgage protection, final expense (burial/funeral), income replacement, retirement savings (IUL), guaranteed income (annuity), and legacy/wealth transfer options. If you're not sure, a licensed professional will help determine the best fit.",
+    a: "You can ask about family and income protection, mortgage responsibilities, final expenses, retirement considerations, and legacy goals. Product availability and suitability vary, so a licensed professional can explain the options available for your circumstances.",
   },
   {
     q: "Can my AI assistant help me sign up?",
@@ -99,7 +103,7 @@ export default function FaqPage() {
       />
       <AEOSpeakablePage
         title="Frequently Asked Questions — Valor Legacies"
-        description="Common questions about military life insurance, SGLI, VGLI, VA programs, and veteran coverage options."
+        description="Common questions about family protection, major life moments, coverage reviews, and veteran insurance considerations."
         url="/faq"
         speakableCssSelectors={["h1", "h2", "p"]}
       />
@@ -116,7 +120,7 @@ export default function FaqPage() {
             Frequently Asked Questions
           </h1>
           <p className="text-sm text-[var(--text-muted)]">
-            Common questions about our free coverage review service.
+            Common questions about planning protection around life’s biggest moments.
           </p>
         </header>
 
@@ -158,7 +162,7 @@ export default function FaqPage() {
         <footer className="pt-8 border-t border-teal-cathedral/10 text-center">
           <nav className="flex gap-4 justify-center mb-3">
             <Link href="/blog" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Blog</Link>
-            <Link href="/resources" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Resources</Link>
+            <Link href="/resources" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Guides</Link>
             <Link href="/about" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">About</Link>
             <Link href="/privacy" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Privacy Policy</Link>
             <Link href="/terms" className="text-teal-cathedral/70 hover:text-teal-cathedral text-xs">Terms of Service</Link>

--- a/digital-cathedral/app/page.tsx
+++ b/digital-cathedral/app/page.tsx
@@ -83,19 +83,19 @@ const TRUST_PILLARS = [
 ];
 
 const RESOURCE_GUIDES = [
-  ["New Parent Protection Checklist", "A simple guide to protecting your growing family after a new baby arrives."],
-  ["Homeowner Protection Guide", "Understand how life insurance can help protect the place your family calls home."],
-  ["Is Work Life Insurance Enough?", "Learn where employer coverage can help — and where gaps may remain."],
-  ["Final Expense Planning Guide", "A clear overview of funeral, burial, and end-of-life expense planning."],
-  ["Veteran Benefits vs. Private Coverage", "Compare basic benefit conversations with additional family protection options."],
-  ["Life Insurance and Retirement Planning", "See how protection may fit into long-term flexibility and confidence."],
-  ["How Much Coverage Does My Family Need?", "Start thinking through income, debts, home needs, children, and future goals."],
+  ["New Parent Protection Checklist", "A simple guide to protecting your growing family after a new baby arrives.", "/guides/new-parent-protection-checklist"],
+  ["Homeowner Protection Guide", "Understand how life insurance can help protect the place your family calls home.", "/guides/homeowner-protection-guide"],
+  ["Is Work Life Insurance Enough?", "Learn where employer coverage can help — and where gaps may remain.", "/guides/employer-life-insurance"],
+  ["Final Expense Planning Guide", "A clear overview of funeral, burial, and end-of-life expense planning.", "/guides/final-expense-planning"],
+  ["Veteran Benefits vs. Private Coverage", "Compare basic benefit conversations with additional family protection options.", "/guides/veteran-benefits-vs-private-coverage"],
+  ["Life Insurance and Retirement Planning", "See how protection may fit into long-term flexibility and confidence.", "/guides/retirement-life-insurance"],
+  ["How Much Coverage Does My Family Need?", "Start thinking through income, debts, home needs, children, and future goals.", "/guides/how-much-coverage-do-i-need"],
 ];
 
-const TESTIMONIALS = [
-  ["After our daughter was born, we realized we had no real plan. Valor Legacies helped us understand our options without pressure.", "New parent placeholder"],
-  ["When we bought our home, we wanted to make sure my wife wouldn’t be stuck with the mortgage. The process was simple and clear.", "Homeowner placeholder"],
-  ["As a veteran, I thought my benefits were enough. Valor Legacies helped me understand what my family would still be responsible for.", "Veteran family placeholder"],
+const CUSTOMER_EXPECTATIONS = [
+  ["Start with your life", "Share the milestone, responsibility, or question that brought you here."],
+  ["Understand the next step", "A licensed professional may help you review available options and considerations."],
+  ["Choose without pressure", "Ask questions, take your time, and decide whether any available option fits your needs."],
 ];
 
 const PURCHASE_INTENT_OPTIONS = [
@@ -308,8 +308,8 @@ export default function HomePage() {
             <p className="mt-5 text-lg text-[#eadcc7]">Helpful guides for life’s biggest moments.</p>
           </div>
           <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
-            {RESOURCE_GUIDES.map(([title, desc]) => (
-              <a key={title} href="/resources" className="rounded-[1.5rem] border border-white/10 bg-white/[0.06] p-6 transition-all hover:-translate-y-1 hover:border-[#d6b35f]/60">
+            {RESOURCE_GUIDES.map(([title, desc, href]) => (
+              <a key={title} href={href} className="rounded-[1.5rem] border border-white/10 bg-white/[0.06] p-6 transition-all hover:-translate-y-1 hover:border-[#d6b35f]/60">
                 <h3 className="font-serif text-2xl">{title}</h3>
                 <p className="mt-3 min-h-[78px] text-sm leading-7 text-[#eadcc7]">{desc}</p>
                 <span className="text-sm font-semibold text-[#d6b35f]">Read Guide</span>
@@ -386,7 +386,7 @@ export default function HomePage() {
                 <div className="space-y-2">
                   <label htmlFor="dateOfBirth" className={LABEL_CLASS}>Date of Birth</label>
                   <input id="dateOfBirth" type="date" value={form.dateOfBirth} onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("dateOfBirth", e.target.value)} autoComplete="bday" aria-required="true" aria-invalid={!!errors.dateOfBirth} className={inputClass(!!errors.dateOfBirth)} />
-                  <p className="text-xs text-[#8a6a3a]">Required to route accurate life insurance guidance. You must be at least 18.</p>
+                  <p className="text-xs text-[#8a6a3a]">Helps determine age-based eligibility and available options. You must be at least 18.</p>
                   {errors.dateOfBirth && <p className="text-xs text-red-600" role="alert">{errors.dateOfBirth}</p>}
                 </div>
 
@@ -400,7 +400,7 @@ export default function HomePage() {
                     {errors.state && <p className="text-xs text-red-600" role="alert">{errors.state}</p>}
                   </div>
                   <div className="space-y-2">
-                    <label htmlFor="purchaseIntent" className={LABEL_CLASS}>Readiness</label>
+                    <label htmlFor="purchaseIntent" className={LABEL_CLASS}>Where are you in the process?</label>
                     <select id="purchaseIntent" value={form.purchaseIntent} onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField("purchaseIntent", e.target.value)} aria-required="true" aria-invalid={!!errors.purchaseIntent} className={selectClass(!!errors.purchaseIntent)}>
                       {PURCHASE_INTENT_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
                     </select>
@@ -501,16 +501,16 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="bg-white px-4 py-20 md:px-8 md:py-28" aria-labelledby="testimonials-heading">
+      <section className="bg-white px-4 py-20 md:px-8 md:py-28" aria-labelledby="expectations-heading">
         <div className="mx-auto max-w-7xl">
-          <p className={SECTION_LABEL}>Stories to replace with approved testimonials</p>
-          <h2 id="testimonials-heading" className={SECTION_HEADING}>Families Come Here at Real Moments.</h2>
+          <p className={SECTION_LABEL}>What to expect</p>
+          <h2 id="expectations-heading" className={SECTION_HEADING}>A Clearer, More Personal Starting Point.</h2>
           <div className="mt-10 grid gap-6 md:grid-cols-3">
-            {TESTIMONIALS.map(([quote, label]) => (
-              <figure key={label} className="rounded-[1.5rem] bg-[#fbf7f0] p-6 shadow-[0_18px_60px_rgba(61,43,24,0.08)]">
-                <blockquote className="font-serif text-2xl leading-snug text-[#241d15]">“{quote}”</blockquote>
-                <figcaption className="mt-5 text-xs font-semibold uppercase tracking-[0.2em] text-[#9f782f]">{label}</figcaption>
-              </figure>
+            {CUSTOMER_EXPECTATIONS.map(([title, desc]) => (
+              <div key={title} className="rounded-[1.5rem] bg-[#fbf7f0] p-6 shadow-[0_18px_60px_rgba(61,43,24,0.08)]">
+                <h3 className="font-serif text-2xl leading-snug text-[#241d15]">{title}</h3>
+                <p className="mt-5 text-sm leading-7 text-[#6a5c4b]">{desc}</p>
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Ensure homepage Resource Center guide cards link to the canonical guide detail pages rather than a generic index for a clearer navigation experience.
- Broaden the `/resources` hub copy and customer-facing language to frame content as “Helpful Guides for Life’s Biggest Moments.”
- Surface the founder story (Andrea Golden) and align About/FAQ language to a broader life-chapter brand while keeping regulatory disclaimers consistent.
- Replace placeholder testimonials with factual expectation cards and refine lead-form wording without changing behavior.

### Description
- Updated `digital-cathedral/app/page.tsx` to add canonical `href` targets to `RESOURCE_GUIDES`, change homepage guide cards to link to the specific `/guides/[slug]` pages, replace `TESTIMONIALS` with `CUSTOMER_EXPECTATIONS`, and adjust form helper text labels (DOB helper and readiness label) while preserving existing form field names, validation, TCPA consent, and submission logic.
- Updated `digital-cathedral/app/about/page.tsx` to add Andrea Golden’s founder story, broaden the mission copy, include new target audiences (new parents, homeowners & families), standardize the independent-resource wording, and add a small Guides/FAQ/privacy/terms footer nav.
- Updated `digital-cathedral/app/faq/page.tsx` to reframe metadata and FAQ entries toward life-chapter planning (added/rewrote questions and answers), standardize the non-affiliation language, and use consistent footer labeling for Guides.
- No assets, build artifacts, minified bundles, or node_modules were added or modified, and no site-wide refactor or changes to lead-form functionality were made.

### Testing
- Ran TypeScript typecheck (`tsc --noEmit`) with no type errors reported.
- Ran the test suite (`node --test tests/*.test.js`) and observed 428 tests passed and 0 failures.
- Ran repository audit checks on the modified files (`node src/cli.js audit check --file ...`) and they reported no assumption mismatches.
- Verified diffs and lint/checks (`git diff --check`) returned no issues, and Playwright screenshot/install attempts failed due to the environment blocking browser downloads (403), which did not affect the code changes or automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bb16447ec8333b131b317499b6e31)