### PR TITLE
Homepage: gold CTA, revised Protection Path copy, Trust and Our Story as their own tabs

### DIFF
--- a/digital-cathedral/app/components/navbar.tsx
+++ b/digital-cathedral/app/components/navbar.tsx
@@ -42,6 +42,8 @@ const NAV_LINKS = [
   { href: "/", label: "Home" },
   { href: "/#life-chapters", label: "Life Chapters" },
   { href: "/#guides", label: "Guides" },
+  { href: "/trust", label: "Why Trust Us" },
+  { href: "/our-story", label: "Our Story" },
   { href: "/about", label: "About" },
   { href: "/#protection-path", label: "Get Started" },
 ];

--- a/digital-cathedral/app/our-story/page.tsx
+++ b/digital-cathedral/app/our-story/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Our Story",
+  description:
+    "Valor Legacies was founded by Andrea Golden, a veteran who built it to make protection feel personal, understandable, and rooted in real life.",
+};
+
+/**
+ * Our story — moved off the homepage into its own tab.
+ *
+ * Keeps the dark founder panel and portrait exactly as the homepage section
+ * presented them; this was a move, not a redesign.
+ *
+ * Note on overlap: /about also carries a founder-story section (added with the
+ * guides/copy work). This page is the fuller telling and /about remains the
+ * mission-plus-contact page, so the header links here for the story. If the two
+ * are ever consolidated, this is the one to keep — /about carries the contact
+ * details and regulatory disclosures that have nowhere else to live.
+ */
+export default function OurStoryPage() {
+  return (
+    <main className="min-h-screen px-4 py-20 md:px-8 md:py-28">
+      <div className="mx-auto max-w-7xl">
+        <Link
+          href="/"
+          className="mb-6 inline-block text-xs uppercase tracking-[0.2em] text-[#6a5c4b] transition-opacity hover:opacity-80"
+        >
+          &larr; Back Home
+        </Link>
+        <div
+          className="grid gap-10 rounded-[2rem] bg-[#241d15] p-8 text-white md:p-12 lg:grid-cols-[1fr_0.7fr] lg:items-center"
+          aria-labelledby="about-heading"
+        >
+          <div>
+            <p className="mb-4 text-xs font-semibold uppercase tracking-[0.32em] text-[#b58b3b]">Our story</p>
+            <h1 id="about-heading" className="font-serif text-4xl font-light md:text-6xl">
+              Veteran-Founded. Family-Focused. Independent.
+            </h1>
+            <p className="mt-6 text-lg leading-8 text-[#eadcc7]">
+              Valor Legacies was created for the families who are building, growing, planning, grieving,
+              dreaming, and trying to make the right decisions for the people they love most.
+            </p>
+            <p className="mt-5 text-lg leading-8 text-[#eadcc7]">
+              As a veteran, service has always meant more to me than a title. It means showing up with
+              purpose. It means protecting others. It means doing the right thing even when no one is
+              watching. That same spirit is the foundation of Valor Legacies. I didn’t build this brand to
+              make life insurance feel complicated or intimidating. I built it to make protection feel
+              personal, understandable, and rooted in real life. Whether someone just had a baby, bought a
+              home, got married, started thinking about retirement, or simply wants to make sure their
+              family is not left with a financial burden, Valor Legacies exists to help them take the next
+              step with confidence.
+            </p>
+            <p className="mt-6 font-serif text-2xl leading-snug text-[#d6b35f]">
+              For the life you live, and the love you leave, this is why Valor Legacies exists.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                href="/#protection-path"
+                className="inline-flex rounded-full bg-[#d6b35f] px-7 py-3 text-sm font-semibold text-[#241d15] transition-all hover:-translate-y-0.5"
+              >
+                Find My Protection Path
+              </Link>
+              <Link
+                href="/about"
+                className="inline-flex rounded-full border border-[#d6b35f]/55 px-7 py-3 text-sm font-semibold text-[#f6e5c4] transition-all hover:-translate-y-0.5"
+              >
+                About &amp; Contact
+              </Link>
+            </div>
+          </div>
+          <figure className="overflow-hidden rounded-[1.5rem] border border-[#d6b35f]/40 bg-gradient-to-br from-[#f6e5c4]/15 to-[#b58b3b]/10 p-3 shadow-[0_30px_90px_rgba(0,0,0,0.35)]">
+            <img
+              src="/assets/valor/founder-andrea-military.jpg"
+              alt="Andrea Golden, veteran and founder of Valor Legacies"
+              className="w-full rounded-[1.15rem]"
+              loading="lazy"
+            />
+            <figcaption className="px-2 pb-1 pt-4 text-center">
+              <p className="font-serif text-2xl text-[#f6e5c4]">Andrea Golden</p>
+              <p className="mt-1 text-xs uppercase tracking-[0.24em] text-[#d6b35f]">Founder · Veteran</p>
+            </figcaption>
+          </figure>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/digital-cathedral/app/page.tsx
+++ b/digital-cathedral/app/page.tsx
@@ -73,15 +73,6 @@ const LIFE_CHAPTERS: { icon: string; title: string; desc: string; cta: string; v
   { icon: "★", title: "Veteran & Military Family Protection", desc: "Your service protected others. Now let’s help protect the people you love most.", cta: "Review Veteran Options", value: "veteran-military-family", video: "military-family.mp4" },
 ];
 
-const TRUST_PILLARS = [
-  ["Veteran-Founded", "Rooted in service, protection, and responsibility."],
-  ["Family-Focused", "Every conversation begins with the people you love most."],
-  ["Independent", "We are not limited to one insurance company."],
-  ["Multiple Highly Rated Carriers", "Options may be reviewed from trusted life insurance providers."],
-  ["No-Pressure Guidance", "Education first. Decisions second."],
-  ["Privacy-Minded Process", "Your information is handled with care and respect."],
-];
-
 const RESOURCE_GUIDES = [
   ["New Parent Protection Checklist", "A simple guide to protecting your growing family after a new baby arrives.", "/guides/new-parent-protection-checklist"],
   ["Homeowner Protection Guide", "Understand how life insurance can help protect the place your family calls home.", "/guides/homeowner-protection-guide"],
@@ -90,12 +81,6 @@ const RESOURCE_GUIDES = [
   ["Veteran Benefits vs. Private Coverage", "Compare basic benefit conversations with additional family protection options.", "/guides/veteran-benefits-vs-private-coverage"],
   ["Life Insurance and Retirement Planning", "See how protection may fit into long-term flexibility and confidence.", "/guides/retirement-life-insurance"],
   ["How Much Coverage Does My Family Need?", "Start thinking through income, debts, home needs, children, and future goals.", "/guides/how-much-coverage-do-i-need"],
-];
-
-const CUSTOMER_EXPECTATIONS = [
-  ["Start with your life", "Share the milestone, responsibility, or question that brought you here."],
-  ["Understand the next step", "A licensed professional may help you review available options and considerations."],
-  ["Choose without pressure", "Ask questions, take your time, and decide whether any available option fits your needs."],
 ];
 
 const PURCHASE_INTENT_OPTIONS = [
@@ -282,23 +267,6 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="bg-gradient-to-b from-[#e4e6ea] to-[#33363d] px-4 py-20 md:px-8 md:py-28" aria-labelledby="trust-heading">
-        <div className="mx-auto max-w-7xl">
-          <div className="mx-auto max-w-3xl text-center">
-            <p className={SECTION_LABEL}>Trust pillars</p>
-            <h2 id="trust-heading" className={SECTION_HEADING}>Guided by Service. Built on Trust.</h2>
-          </div>
-          <div className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {TRUST_PILLARS.map(([title, desc]) => (
-              <div key={title} className="rounded-[1.5rem] border border-white/60 bg-white p-6 shadow-[0_12px_34px_rgba(0,0,0,0.12)]">
-                <h3 className="font-serif text-2xl text-[#241d15]">{title}</h3>
-                <p className="mt-3 leading-7 text-[#6a5c4b]">{desc}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       <section id="guides" className="bg-[#211a13] px-4 py-20 text-white md:px-8 md:py-28" aria-labelledby="guides-heading">
         <div className="mx-auto max-w-7xl">
           <div className="max-w-3xl">
@@ -325,7 +293,7 @@ export default function HomePage() {
           <div className="mt-12 grid gap-6 md:grid-cols-3">
             {[
               ["Tell us what changed.", "Share the milestone, responsibility, or concern that brought you here."],
-              ["Understand the next step", "A licensed professional may help you review available options and considerations."],
+              ["Understand the next step.", "A licensed professional may help you review available options and considerations."],
               ["Get guidance that fits your life.", "Ask questions and decide which available option fits your needs."],
             ].map(([title, desc], index) => (
               <div key={title} className="rounded-[1.75rem] bg-white p-8 text-left shadow-[0_20px_70px_rgba(61,43,24,0.08)]">
@@ -497,41 +465,6 @@ export default function HomePage() {
               </div>
             )}
           </form>
-        </div>
-      </section>
-
-      <section className="bg-white px-4 py-20 md:px-8 md:py-28" aria-labelledby="expectations-heading">
-        <div className="mx-auto max-w-7xl">
-          <p className={SECTION_LABEL}>What to expect</p>
-          <h2 id="expectations-heading" className={SECTION_HEADING}>A Clearer, More Personal Starting Point.</h2>
-          <div className="mt-10 grid gap-6 md:grid-cols-3">
-            {CUSTOMER_EXPECTATIONS.map(([title, desc]) => (
-              <div key={title} className="rounded-[1.5rem] bg-[#fbf7f0] p-6 shadow-[0_18px_60px_rgba(61,43,24,0.08)]">
-                <h3 className="font-serif text-2xl leading-snug text-[#241d15]">{title}</h3>
-                <p className="mt-5 text-sm leading-7 text-[#6a5c4b]">{desc}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="about" className="px-4 py-20 md:px-8 md:py-28" aria-labelledby="about-heading">
-        <div className="mx-auto grid max-w-7xl gap-10 rounded-[2rem] bg-[#241d15] p-8 text-white md:p-12 lg:grid-cols-[1fr_0.7fr] lg:items-center">
-          <div>
-            <p className={SECTION_LABEL}>Our story</p>
-            <h2 id="about-heading" className="font-serif text-4xl font-light md:text-6xl">Veteran-Founded. Family-Focused. Independent.</h2>
-            <p className="mt-6 text-lg leading-8 text-[#eadcc7]">Valor Legacies was created for the families who are building, growing, planning, grieving, dreaming, and trying to make the right decisions for the people they love most.</p>
-            <p className="mt-5 text-lg leading-8 text-[#eadcc7]">As a veteran, service has always meant more to me than a title. It means showing up with purpose. It means protecting others. It means doing the right thing even when no one is watching. That same spirit is the foundation of Valor Legacies. I didn’t build this brand to make life insurance feel complicated or intimidating. I built it to make protection feel personal, understandable, and rooted in real life. Whether someone just had a baby, bought a home, got married, started thinking about retirement, or simply wants to make sure their family is not left with a financial burden, Valor Legacies exists to help them take the next step with confidence.</p>
-            <p className="mt-6 font-serif text-2xl leading-snug text-[#d6b35f]">For the life you live, and the love you leave, this is why Valor Legacies exists.</p>
-            <a href="/about" className="mt-8 inline-flex rounded-full bg-[#d6b35f] px-7 py-3 text-sm font-semibold text-[#241d15]">Our Story</a>
-          </div>
-          <figure className="overflow-hidden rounded-[1.5rem] border border-[#d6b35f]/40 bg-gradient-to-br from-[#f6e5c4]/15 to-[#b58b3b]/10 p-3 shadow-[0_30px_90px_rgba(0,0,0,0.35)]">
-            <img src="/assets/valor/founder-andrea-military.jpg" alt="Andrea Golden, veteran and founder of Valor Legacies" className="w-full rounded-[1.15rem]" loading="lazy" />
-            <figcaption className="px-2 pb-1 pt-4 text-center">
-              <p className="font-serif text-2xl text-[#f6e5c4]">Andrea Golden</p>
-              <p className="mt-1 text-xs uppercase tracking-[0.24em] text-[#d6b35f]">Founder · Veteran</p>
-            </figcaption>
-          </figure>
         </div>
       </section>
 

--- a/digital-cathedral/app/page.tsx
+++ b/digital-cathedral/app/page.tsx
@@ -143,7 +143,6 @@ const INPUT_ERROR = INPUT_CLASS + " border-red-500 bg-red-50/70 focus:border-red
 const SELECT_CLASS = INPUT_CLASS + " appearance-none";
 const LABEL_CLASS = "block text-sm font-semibold text-[#2a2219]";
 const BTN_PRIMARY = "rounded-full bg-[#b58b3b] px-7 py-3 text-sm font-semibold text-white shadow-[0_18px_45px_rgba(82,55,17,0.28)] transition-all hover:-translate-y-0.5 hover:bg-[#9f782f] focus-visible:outline-[#f4d58d]";
-const BTN_SECONDARY = "rounded-full border border-[#d9c08a]/55 bg-white/10 px-7 py-3 text-sm font-semibold text-white backdrop-blur transition-all hover:-translate-y-0.5 hover:bg-white/15";
 const BTN_BACK = "rounded-full border border-[#d9cdbb] px-6 py-3 text-sm font-semibold text-[#6c5a40] transition-all hover:border-[#b58b3b]";
 const SECTION_LABEL = "mb-4 text-xs font-semibold uppercase tracking-[0.32em] text-[#b58b3b]";
 const SECTION_HEADING = "font-serif text-3xl font-light leading-tight text-[#211a13] md:text-5xl";
@@ -250,7 +249,7 @@ export default function HomePage() {
             <p className="mt-7 max-w-2xl text-lg leading-8 text-[#f8ead2] md:text-xl">Life changes in beautiful, unexpected, and meaningful ways. Valor Legacies helps families find life insurance guidance for the moments that matter most.</p>
             <div className="mt-10 flex flex-col gap-3 sm:flex-row">
               <a href="#protection-path" className={BTN_PRIMARY}>Find My Protection Path</a>
-              <a href="#life-chapters" className={BTN_SECONDARY}>Explore Life Chapters</a>
+              <a href="#life-chapters" className={BTN_PRIMARY}>Explore Life Chapters</a>
             </div>
           </div>
         </div>
@@ -325,9 +324,9 @@ export default function HomePage() {
           <h2 id="how-heading" className={SECTION_HEADING}>You Don’t Have to Figure This Out Alone.</h2>
           <div className="mt-12 grid gap-6 md:grid-cols-3">
             {[
-              ["Tell us what changed.", "Choose the life event or concern that brought you here."],
-              ["Understand your options.", "We help make life insurance simple, clear, and relatable."],
-              ["Get guidance that fits your life.", "A licensed professional can help review options based on your needs, goals, health, and budget."],
+              ["Tell us what changed.", "Share the milestone, responsibility, or concern that brought you here."],
+              ["Understand the next step", "A licensed professional may help you review available options and considerations."],
+              ["Get guidance that fits your life.", "Ask questions and decide which available option fits your needs."],
             ].map(([title, desc], index) => (
               <div key={title} className="rounded-[1.75rem] bg-white p-8 text-left shadow-[0_20px_70px_rgba(61,43,24,0.08)]">
                 <div className="mb-8 flex h-12 w-12 items-center justify-center rounded-full bg-[#d6b35f] font-bold text-white">{index + 1}</div>

--- a/digital-cathedral/app/sitemap.ts
+++ b/digital-cathedral/app/sitemap.ts
@@ -72,6 +72,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
           priority: 0.7,
         },
         {
+          url: `${baseUrl}/our-story`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.7,
+        },
+        {
+          url: `${baseUrl}/trust`,
+          lastModified: new Date(),
+          changeFrequency: "monthly",
+          priority: 0.7,
+        },
+        {
           url: `${baseUrl}/faq`,
           lastModified: new Date(),
           changeFrequency: "monthly",

--- a/digital-cathedral/app/trust/page.tsx
+++ b/digital-cathedral/app/trust/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Why Families Trust Us",
+  description:
+    "Veteran-founded, family-focused, and independent. The principles behind how Valor Legacies works with the families it serves.",
+};
+
+/**
+ * Trust pillars — moved off the homepage into its own tab.
+ *
+ * The markup keeps the presentation it had as a homepage section (the same
+ * gradient ground and card treatment) rather than being restyled into the
+ * narrow document shell that /about and /faq use. This was a move, not a
+ * redesign: a visitor following the header link should recognise the section
+ * they remember, and the cards carry their own visual weight.
+ */
+const TRUST_PILLARS: [string, string][] = [
+  ["Veteran-Founded", "Rooted in service, protection, and responsibility."],
+  ["Family-Focused", "Every conversation begins with the people you love most."],
+  ["Independent", "We are not limited to one insurance company."],
+  ["Multiple Highly Rated Carriers", "Options may be reviewed from trusted life insurance providers."],
+  ["No-Pressure Guidance", "Education first. Decisions second."],
+  ["Privacy-Minded Process", "Your information is handled with care and respect."],
+];
+
+export default function TrustPage() {
+  return (
+    <main className="min-h-screen">
+      <section
+        className="bg-gradient-to-b from-[#e4e6ea] to-[#33363d] px-4 py-20 md:px-8 md:py-28"
+        aria-labelledby="trust-heading"
+      >
+        <div className="mx-auto max-w-7xl">
+          <div className="mx-auto max-w-3xl text-center">
+            <Link
+              href="/"
+              className="mb-6 inline-block text-xs uppercase tracking-[0.2em] text-[#6a5c4b] transition-opacity hover:opacity-80"
+            >
+              &larr; Back Home
+            </Link>
+            <p className="mb-4 text-xs font-semibold uppercase tracking-[0.32em] text-[#b58b3b]">Trust pillars</p>
+            <h1 id="trust-heading" className="font-serif text-3xl font-light leading-tight text-[#211a13] md:text-5xl">
+              Guided by Service. Built on Trust.
+            </h1>
+          </div>
+          <div className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {TRUST_PILLARS.map(([title, desc]) => (
+              <div
+                key={title}
+                className="rounded-[1.5rem] border border-white/60 bg-white p-6 shadow-[0_12px_34px_rgba(0,0,0,0.12)]"
+              >
+                <h2 className="font-serif text-2xl text-[#241d15]">{title}</h2>
+                <p className="mt-3 leading-7 text-[#6a5c4b]">{desc}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-12 text-center">
+            <Link
+              href="/#protection-path"
+              className="inline-flex rounded-full bg-[#b58b3b] px-7 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-[#9f782f]"
+            >
+              Find My Protection Path
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
Homepage refinements, previewed and approved. Two commits.

## Gold CTA + Protection Path copy (`3e7e00d`)
- **"Explore Life Chapters"** now uses `BTN_PRIMARY`, rendering the same `#b58b3b` gold as "Find My Protection Path" instead of the translucent white pill. `BTN_SECONDARY` had exactly one call site — this one — so it was removed rather than left as a style nothing points at.
- Protection Path steps reworded, and steps 2 and 3 now attribute review to a **licensed professional** rather than to Valor Legacies, matching the disclaimer language merged in #309:
  - "Choose the life event or concern that brought you here." → "Share the milestone, responsibility, or concern that brought you here."
  - "Understand your options. / We help make life insurance simple, clear, and relatable." → "Understand the next step. / A licensed professional may help you review available options and considerations."
  - "A licensed professional can help review options based on your needs, goals, health, and budget." → "Ask questions and decide which available option fits your needs."

## Section removal and two new tabs (`b1bba36`)
- **"What to expect" removed.** It restated the Protection Path steps directly above it, so with that copy revised it was saying the same thing twice on one screen.
- **Trust pillars → `/trust`** ("Why Trust Us") and **Our story → `/our-story`**, both linked from the header dropdown. Each page keeps the presentation it had as a homepage section — the same gradient ground and cards for the pillars, the same dark panel and portrait for the story. This was a move, not a redesign.
- `TRUST_PILLARS` and `CUSTOMER_EXPECTATIONS` removed from `page.tsx`; no constant is left behind with nothing reading it.
- Both routes added to the sitemap — they are real pages now, not anchors, and nothing else would tell a crawler they exist.

The homepage now runs life chapters → guides → how it works → protection path form, and ends on the form rather than on two static sections after it.

## Verification
Checked in the built output and on the preview deployment, not just the source:
- Every removed string is gone from the homepage and present on `/trust` and `/our-story`; both routes prerender and serve 200
- `Understand the next step.` carries its period; both CTAs render `bg-[#b58b3b]`
- **No dead anchors** — nothing referenced `#about`, `#trust` or `#expectations`
- The two new header links are in the layout chunk; the dropdown renders on open, so they are correctly absent from SSR html, as every other menu link already is
- `tsc --noEmit` clean, `next build` compiled successfully
- Goggles: page.tsx 0.948, navbar 0.955, trust 0.914, our-story 0.909, sitemap 0.909 — all CONSONANT, META-DEBUG clean on every file
- All ten gates hold (covenant reading from the tracked seed floor, high=16 total=172 ast=11)

## Note
`/about` also carries a founder-story section from #309, so the story now appears in two places. Both are left in place deliberately — `/our-story` is the fuller telling and `/about` keeps the contact details and regulatory disclosures. Worth a follow-up decision, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW

---
_Generated by [Claude Code](https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW)_