### PR TITLE
Standardize the consumer contact window at 3 business days; wire the HowTo schema

### DIFF
--- a/digital-cathedral/app/api/leads/route.ts
+++ b/digital-cathedral/app/api/leads/route.ts
@@ -41,7 +41,7 @@ const FALLBACK_CONFIRMATIONS = [
   "Your request has been received. A licensed professional will reach out soon.",
   "Thank you for taking the first step. Someone who understands military coverage will be in touch.",
   "Your information is secure. A licensed insurance professional will contact you shortly.",
-  "We've received your request. Expect a call or email within 1 business day.",
+  "We've received your request. Expect a call or email within 3 business days.",
   "You're one step closer to protecting your family. A professional will reach out soon.",
 ];
 

--- a/digital-cathedral/app/components/aeo-schema.tsx
+++ b/digital-cathedral/app/components/aeo-schema.tsx
@@ -182,9 +182,9 @@ export function AEOHowTo() {
   const data: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "HowTo",
-    name: "How to Get a Free Life Insurance Coverage Review for Veterans",
+    name: "How to Get a Free Life Insurance Coverage Review",
     description:
-      "Step-by-step guide to getting a free, no-obligation life insurance coverage review through Valor Legacies. Takes less than 60 seconds.",
+      "Step-by-step guide to requesting a free, no-obligation life insurance coverage review through Valor Legacies, whatever life moment brought you here. Takes less than 60 seconds.",
     totalTime: "PT1M",
     tool: {
       "@type": "HowToTool",

--- a/digital-cathedral/app/lib/email.ts
+++ b/digital-cathedral/app/lib/email.ts
@@ -154,7 +154,7 @@ export async function sendLeadConfirmationEmail(lead: {
   const text = [
     `Hi ${lead.firstName},`,
     ``,
-    `Thank you for reaching out about ${coverageLabel}. We've received your request and a licensed insurance professional will contact you within 1 business day.`,
+    `Thank you for reaching out about ${coverageLabel}. We've received your request and a licensed insurance professional will contact you within 3 business days.`,
     ``,
     `What happens next:`,
     `1. A licensed agent in your area will review your request`,
@@ -188,7 +188,7 @@ export async function sendLeadConfirmationEmail(lead: {
   <div style="padding: 32px; background-color: #FFFFFF;">
     <p style="font-size: 16px; margin-top: 0;">Hi <strong>${lead.firstName}</strong>,</p>
 
-    <p>Thank you for reaching out about <strong>${coverageLabel}</strong>. We've received your request and a licensed insurance professional will contact you within <strong>1 business day</strong>.</p>
+    <p>Thank you for reaching out about <strong>${coverageLabel}</strong>. We've received your request and a licensed insurance professional will contact you within <strong>3 business days</strong>.</p>
 
     <!-- What happens next -->
     <div style="background: #F0F2F5; border-left: 3px solid #2D8659; padding: 16px 20px; margin: 24px 0; border-radius: 0 6px 6px 0;">

--- a/digital-cathedral/app/lib/sms.ts
+++ b/digital-cathedral/app/lib/sms.ts
@@ -106,7 +106,7 @@ export async function sendLeadSms(lead: {
 
   const body =
     `Hi ${lead.firstName}, thank you for your interest in ${coverageLabel}. ` +
-    `A licensed professional will contact you within 1 business day. ` +
+    `A licensed professional will contact you within 3 business days. ` +
     `Ref: ${lead.leadId} — Valor Legacies`;
 
   try {

--- a/digital-cathedral/app/page.tsx
+++ b/digital-cathedral/app/page.tsx
@@ -13,6 +13,7 @@ import { useLeadForm, FIELD_STEP } from "./protect/hooks/use-lead-form";
 import { TcpaConsent } from "./protect/components/tcpa-consent";
 import { StepProgress } from "./protect/components/step-progress";
 import { useUtmTracking } from "./protect/hooks/use-utm-tracking";
+import { AEOHowTo } from "./components/aeo-schema";
 
 const US_STATES = [
   { code: "AL", name: "Alabama" }, { code: "AK", name: "Alaska" },
@@ -207,6 +208,11 @@ export default function HomePage() {
 
   return (
     <main className="overflow-hidden bg-[#f6f0e6] text-[#241d15]">
+      {/* Invisible to visitors: the step-by-step schema answer engines read for
+          "how do I get a coverage review". It belongs on this page because these
+          are the steps of the Protection Path form below. The component existed
+          but nothing rendered it, so it had never reached an engine. */}
+      <AEOHowTo />
       <section id="home" className="relative flex min-h-[92vh] items-center px-4 py-24 text-white md:px-8" aria-labelledby="hero-heading">
         {/* Static base — shown while the video loads and for reduced-motion visitors */}
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_20%,rgba(214,179,95,0.34),transparent_28%),linear-gradient(120deg,rgba(19,16,13,0.96),rgba(31,25,19,0.82)_45%,rgba(65,45,24,0.5)),url('/og-image.svg')] bg-cover bg-center" aria-hidden="true" />


### PR DESCRIPTION
One commit. Fixes an inconsistency found while reviewing the answer-engine schema.

## The contact window was four different promises
The site told people four different things about when someone would reach them. Every consumer-facing promise is now **three business days**, the window confirmed as accurate:

| Where | Was | Now |
|---|---|---|
| Confirmation email (plain text) | 1 business day | **3 business days** |
| Confirmation email (HTML) | 1 business day | **3 business days** |
| Confirmation SMS | 1 business day | **3 business days** |
| Form submission response | 1 business day | **3 business days** |
| HowTo schema step 3 | already 3 | unchanged |

The HTML email needed its own edit — the number sits inside `<strong>` tags, so a plain search-and-replace passed over it while reporting success on the file.

## Deliberately unchanged
These are different promises to different people, and folding them in would have been wrong:

- **24h duplicate-submission detection** (`api/agent/leads`, `lib/database`) — internal logic
- **24h agent consent expiry** (developers page) — documented API behaviour
- **1 and 5 business days, 48h** (`api/client/returns`, `portal/terms`) — marketplace SLAs owed to buyers, not consumers
- **15 business days for deletion requests** (privacy page) — a legal window; changing it would have been a compliance error
- **"in the last 24 hours"** (trust signals) — social proof, not a promise

## HowTo schema wired and retitled
`AEOHowTo` was exported and rendered by nothing, so the step-by-step schema answer engines read for "how do I get a coverage review" never reached one. It now renders on the homepage, where the Protection Path form it describes lives.

Retitled from *"How to Get a Free Life Insurance Coverage Review **for Veterans**"* — publishing that would have pushed military-only framing back out to search engines immediately after the rest of the site moved away from it.

## Verification
- Built HTML: homepage carries one HowTo block with HowToStep entries, the broadened title, and "within 3 business days"; the veterans-only title is gone
- The three schema steps match what the form actually collects (name, DOB, state, email, phone, TCPA consent)
- `tsc --noEmit` clean, `next build` compiled from a cleared cache
- Goggles: leads route 0.952, aeo-schema 0.915, email 0.965, sms 0.958, page 0.949 — all CONSONANT, META-DEBUG clean
- All ten gates hold

## Note for later
Three business days is a weaker promise than the one business day leads were previously told. If agents typically reach people sooner, this under-promises and may cost conversions — flagged and consciously accepted for now; reverting is a one-line change in four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW

---
_Generated by [Claude Code](https://claude.ai/code/session_011yb66SEM2L6NQTihi2pAiW)_