### PR TITLE
feat(portal): role-based portal landing, portal shell, admin & agent dashboard shells

### DIFF
--- a/digital-cathedral/app/admin/dashboard/page.tsx
+++ b/digital-cathedral/app/admin/dashboard/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { MetricCard, Panel, PortalShell } from "../../components/portal-shell";
+
+type AdminStats = { today: number; total: number; thisWeek: number; thisMonth: number; byState?: Record<string, number>; byCoverage?: Record<string, number>; bySource?: { human: number; agent: number; lattice: number } };
+
+export default function AdminCommandCenter() {
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [pendingAgents, setPendingAgents] = useState(0);
+  useEffect(() => { Promise.all([fetch("/api/admin/stats"), fetch("/api/admin/revenue")]).then(async ([s, r]) => { if (s.ok) setStats((await s.json()).stats); if (r.ok) setPendingAgents((await r.json())?.stats?.pendingClients ?? 0); }); }, []);
+  const topStates = Object.entries(stats?.byState ?? {}).sort((a,b) => b[1]-a[1]).slice(0,4);
+  return <PortalShell role="admin" eyebrow="Command center" title="Business health at a glance" description="Monitor lead speed, revenue activity, agent readiness, and compliance pressure from one focused workspace.">
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4"><MetricCard label="New leads today" value={stats?.today ?? "—"} note="Live lead intake"/><MetricCard label="Unassigned leads" value="—" note="Assignment data needed"/><MetricCard label="Over 5 min" value="—" note="Contact event data needed" urgent/><MetricCard label="Leads sold today" value="—" note="Purchase timestamp needed"/><MetricCard label="Revenue today" value="—" note="Daily ledger rollup needed"/><MetricCard label="Pending approvals" value={pendingAgents} note="Agent applications" urgent={pendingAgents > 0}/><MetricCard label="Compliance alerts" value="—" note="Consent flag rollup needed"/><MetricCard label="Open disputes" value="—" note="Dispute status rollup needed"/></div>
+    <div className="mt-5 grid gap-5 xl:grid-cols-2">
+      <Panel title="Urgent attention" action={<Link href="/admin/leads" className="text-xs font-bold text-[#94732e]">Open lead center →</Link>}><Empty text="No live urgency feed is connected yet. Once assignment, contact, and dispute events are available, the highest-impact actions will appear here."/></Panel>
+      <Panel title="Lead flow"><div className="space-y-3">{topStates.length ? topStates.map(([state,count]) => <div key={state} className="flex items-center gap-3"><span className="w-8 text-sm font-bold">{state}</span><div className="h-2 flex-1 overflow-hidden rounded-full bg-[#eee7da]"><div className="h-full rounded-full bg-[#c9a75f]" style={{width:`${Math.max(8, count / Math.max(...topStates.map(([,n])=>n)) * 100)}%`}}/></div><span className="w-8 text-right text-sm">{count}</span></div>) : <Empty text="Lead flow will populate as lead intake data becomes available."/>}</div></Panel>
+      <Panel title="Revenue snapshot"><Empty text="Connect sales, subscriptions, credit purchases, refunds, and chargebacks to show net revenue here."/></Panel>
+      <Panel title="Agent performance"><Empty text="Contact events and outcome tracking are needed to surface fast responders, inactive agents, and conversion activity."/></Panel>
+      <div className="xl:col-span-2"><Panel title="Compliance watch"><div className="grid gap-3 sm:grid-cols-3"><Status label="Consent gaps"/><Status label="Opt-outs & DNC"/><Status label="Deletion requests"/></div></Panel></div>
+    </div>
+  </PortalShell>;
+}
+
+function Empty({ text }: { text: string }) { return <div className="rounded-xl border border-dashed border-[#d9cfbd] bg-[#faf8f3] p-5 text-sm leading-6 text-[#776e61]">{text}</div>; }
+function Status({ label }: { label: string }) { return <div className="flex items-center justify-between rounded-xl bg-[#f7f3eb] p-4"><span className="text-sm font-semibold">{label}</span><span className="text-xs text-[#857b6d]">Awaiting data</span></div>; }

--- a/digital-cathedral/app/agent/dashboard/page.tsx
+++ b/digital-cathedral/app/agent/dashboard/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { MetricCard, Panel, PortalShell } from "../../components/portal-shell";
+
+type Lead = { leadId: string; firstName: string; lastName: string; coverageInterest: string; state: string; createdAt: string };
+type User = { firstName: string };
+
+export default function AgentDailyHub() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => { fetch("/api/portal/session").then(async r => { if (!r.ok) throw new Error(); const data = await r.json(); setUser(data.user); setLeads(data.leads ?? []); }).catch(() => router.replace("/portal/login")).finally(() => setLoading(false)); }, [router]);
+  if (loading || !user) return <main className="grid min-h-screen place-items-center bg-[#171714] text-sm text-[#d8d0c3]">Preparing your daily workspace…</main>;
+  const pipeline = ["New", "Contacted", "Follow-Up", "Appointment Set", "Application Started", "Submitted", "Won", "Lost"];
+  return <PortalShell role="agent" eyebrow="Daily work hub" title={`Good to see you, ${user.firstName}`} description="Start with the freshest opportunity, complete today’s follow-ups, and keep every lead moving forward.">
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4"><MetricCard label="New purchased leads" value={leads.length} note="Ready for first contact" urgent={leads.length > 0}/><MetricCard label="Not contacted" value={leads.length ? "—" : 0} note={leads.length ? "Contact events needed" : "You are caught up"}/><MetricCard label="Follow-ups today" value="—" note="Task data needed"/><MetricCard label="Appointments today" value="—" note="Calendar data needed"/><MetricCard label="Credits available" value="—" note="Credit balance needed"/><MetricCard label="Month purchases" value="—" note="Purchase rollup needed"/><MetricCard label="Estimated ROI" value="—" note="Available after outcome tracking"/></div>
+    <div className="mt-5 grid gap-5 xl:grid-cols-[1.2fr_.8fr]">
+      <Panel title="Today’s priority leads" action={<Link href="/agent/leads" className="text-xs font-bold text-[#94732e]">View all →</Link>}>{leads.length ? <div className="space-y-2">{leads.slice(0,4).map((lead,i) => <div key={lead.leadId} className="flex items-center justify-between gap-3 rounded-xl border border-[#e8e0d2] p-4"><div className="min-w-0"><div className="flex items-center gap-2"><span className="rounded-full bg-amber-100 px-2 py-1 text-[10px] font-bold uppercase text-amber-800">Priority {i+1}</span><strong className="truncate text-sm">{lead.firstName} {lead.lastName}</strong></div><p className="mt-2 text-xs text-[#776e61]">{lead.state} · {lead.coverageInterest || "Coverage guidance"} · {new Date(lead.createdAt).toLocaleDateString()}</p></div><button className="rounded-full bg-[#211d18] px-4 py-2 text-xs font-bold text-white">Open</button></div>)}</div> : <div className="rounded-xl border border-dashed border-[#d9cfbd] bg-[#faf8f3] p-7 text-center"><h3 className="font-serif text-lg">Your lead queue is ready when you are.</h3><p className="mx-auto mt-2 max-w-md text-sm leading-6 text-[#776e61]">You do not have any leads yet. Visit the marketplace to find leads that match your licensed states and focus areas.</p><Link href="/portal/marketplace" className="mt-4 inline-block rounded-full bg-[#c9a75f] px-5 py-2.5 text-xs font-bold">Browse leads</Link></div>}</Panel>
+      <Panel title="Quick actions"><div className="grid grid-cols-2 gap-2">{[["Buy Leads","/portal/marketplace"],["Open My Leads","/agent/leads"],["View Scripts","/agent/training"],["Add Appointment","/agent/tasks"],["Contact Support","/agent/support"]].map(([label,href]) => <Link key={label} href={href} className="rounded-xl border border-[#e2d9c9] p-3 text-sm font-semibold hover:border-[#c9a75f] hover:bg-[#faf7f0]">{label}<span className="mt-2 block text-[#b18a38]">→</span></Link>)}</div></Panel>
+      <div className="xl:col-span-2"><Panel title="My pipeline"><div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8">{pipeline.map((stage,i) => <div key={stage} className="rounded-xl bg-[#f6f1e8] p-3"><span className="text-[10px] font-bold uppercase tracking-wide text-[#857b6d]">{stage}</span><p className="mt-3 font-serif text-2xl">{i === 0 ? leads.length : "—"}</p></div>)}</div></Panel></div>
+      <div className="xl:col-span-2"><Panel title="Golden Standard tip"><blockquote className="border-l-2 border-[#c9a75f] pl-5 text-sm leading-7 text-[#62594e]">Speed matters, but clarity earns trust. Open by acknowledging the consumer’s life chapter, confirm why they asked for guidance, and agree on the next useful step.</blockquote></Panel></div>
+    </div>
+  </PortalShell>;
+}

--- a/digital-cathedral/app/components/portal-shell.tsx
+++ b/digital-cathedral/app/components/portal-shell.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import type { ReactNode } from "react";
+
+export type PortalRole = "admin" | "agent" | "developer";
+
+const NAVIGATION: Record<PortalRole, { label: string; href: string }[]> = {
+  admin: [
+    { label: "Dashboard", href: "/admin/dashboard" },
+    { label: "Leads", href: "/admin/leads" },
+    { label: "Agents", href: "/admin/clients" },
+    { label: "Lead Marketplace", href: "/portal/marketplace" },
+    { label: "Orders & Payments", href: "/admin/payments" },
+    { label: "Compliance", href: "/admin/compliance" },
+    { label: "Analytics", href: "/admin/analytics" },
+    { label: "Content / Campaigns", href: "/admin" },
+    { label: "Support / Disputes", href: "/admin/disputes" },
+    { label: "Settings", href: "/admin/ops" },
+  ],
+  agent: [
+    { label: "Dashboard", href: "/agent/dashboard" },
+    { label: "Buy Leads", href: "/portal/marketplace" },
+    { label: "My Leads", href: "/agent/leads" },
+    { label: "Pipeline", href: "/agent/pipeline" },
+    { label: "Appointments / Tasks", href: "/agent/tasks" },
+    { label: "Scripts & Training", href: "/agent/training" },
+    { label: "Billing / Credits", href: "/agent/billing" },
+    { label: "Performance", href: "/agent/performance" },
+    { label: "Support", href: "/agent/support" },
+  ],
+  developer: [
+    { label: "Developer Dashboard", href: "/developers" },
+    { label: "API Documentation", href: "/developers/agents" },
+    { label: "API Keys", href: "/developers#api-keys" },
+    { label: "Consent Flow", href: "/developers#consent" },
+    { label: "Webhooks / Logs", href: "/developers#webhooks" },
+    { label: "Usage", href: "/developers#usage" },
+    { label: "Support", href: "/developers#support" },
+  ],
+};
+
+export function PortalShell({ role, eyebrow, title, description, children }: {
+  role: PortalRole;
+  eyebrow: string;
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  async function logout() {
+    await fetch(role === "admin" ? "/api/admin/logout" : "/api/portal/logout", { method: "POST" });
+    router.replace(role === "admin" ? "/admin/login" : "/portal/login");
+  }
+
+  return (
+    <div className="min-h-screen bg-[#f4efe5] text-[#211d18] lg:grid lg:grid-cols-[260px_1fr]">
+      <aside className="border-b border-white/10 bg-[#171714] text-[#f7f0e3] lg:sticky lg:top-0 lg:h-screen lg:border-b-0 lg:border-r">
+        <div className="flex items-center justify-between px-5 py-5 lg:block lg:px-6 lg:py-7">
+          <Link href="/portal" className="flex items-center gap-3" aria-label="Valor Legacies portal home">
+            <span className="grid h-9 w-9 place-items-center rounded-full border border-[#c9a75f]/45 bg-[#c9a75f]/10 font-serif text-lg text-[#d5b972]">V</span>
+            <span><strong className="block text-sm tracking-wide">Valor Legacies</strong><small className="text-[10px] uppercase tracking-[0.22em] text-[#c9a75f]">Operations portal</small></span>
+          </Link>
+          <span className="rounded-full border border-[#c9a75f]/25 px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-[#d5b972] lg:mt-6 lg:inline-block">{role}</span>
+        </div>
+        <nav className="flex gap-1 overflow-x-auto px-4 pb-4 lg:block lg:space-y-1 lg:overflow-visible lg:px-3" aria-label={`${role} navigation`}>
+          {NAVIGATION[role].map((item) => {
+            const active = pathname === item.href || (item.href !== "/admin" && pathname.startsWith(`${item.href}/`));
+            return <Link key={item.label} href={item.href} className={`whitespace-nowrap rounded-xl px-3 py-2.5 text-sm transition lg:block ${active ? "bg-[#c9a75f] font-semibold text-[#181510]" : "text-[#cfc7b9] hover:bg-white/5 hover:text-white"}`} aria-current={active ? "page" : undefined}>{item.label}</Link>;
+          })}
+        </nav>
+        <div className="hidden border-t border-white/10 p-4 lg:absolute lg:inset-x-0 lg:bottom-0 lg:block">
+          <button onClick={logout} className="w-full rounded-xl border border-white/10 px-3 py-2 text-left text-sm text-[#cfc7b9] hover:border-[#c9a75f]/50 hover:text-white">Sign out</button>
+        </div>
+      </aside>
+      <main className="min-w-0 px-4 py-6 sm:px-7 lg:px-10 lg:py-9">
+        <header className="mb-7 flex flex-wrap items-end justify-between gap-4 border-b border-[#d9cfbd] pb-6">
+          <div><p className="mb-2 text-[11px] font-bold uppercase tracking-[0.24em] text-[#94732e]">{eyebrow}</p><h1 className="font-serif text-3xl leading-tight sm:text-4xl">{title}</h1><p className="mt-2 max-w-2xl text-sm leading-6 text-[#71695e]">{description}</p></div>
+          <div className="flex items-center gap-2"><span className="h-2 w-2 rounded-full bg-emerald-500"/><span className="text-xs font-medium text-[#71695e]">Systems operational</span></div>
+        </header>
+        {children}
+      </main>
+    </div>
+  );
+}
+
+export function MetricCard({ label, value, note, urgent = false }: { label: string; value: string | number; note: string; urgent?: boolean }) {
+  return <article className={`rounded-2xl border bg-white p-5 shadow-[0_8px_30px_rgba(39,32,20,0.05)] ${urgent ? "border-amber-300" : "border-[#e2d9c9]"}`}><p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#776e61]">{label}</p><p className="mt-3 font-serif text-3xl text-[#211d18]">{value}</p><p className={`mt-2 text-xs ${urgent ? "font-medium text-amber-700" : "text-[#8a8175]"}`}>{note}</p></article>;
+}
+
+export function Panel({ title, action, children }: { title: string; action?: ReactNode; children: ReactNode }) {
+  return <section className="rounded-2xl border border-[#e2d9c9] bg-white p-5 shadow-[0_8px_30px_rgba(39,32,20,0.04)]"><div className="mb-5 flex items-center justify-between gap-3"><h2 className="font-serif text-xl">{title}</h2>{action}</div>{children}</section>;
+}

--- a/digital-cathedral/app/portal/page.tsx
+++ b/digital-cathedral/app/portal/page.tsx
@@ -1,15 +1,6 @@
-import { redirect } from "next/navigation";
+import { PortalLanding } from "./portal-landing";
 
-/**
- * /portal — Agent entry point.
- *
- * Server-side redirects to /portal/login. The login page itself bounces
- * already-authenticated agents to /portal/dashboard, so the full chain is:
- *   /portal  →  /portal/login  →  (if session)  /portal/dashboard
- * Collapsing /portal to a pure redirect eliminates the duplicate inline
- * login form that previously lived here, so there's exactly one login
- * surface and one POST target (/api/portal/login) instead of two.
- */
-export default function PortalIndexPage(): never {
-  redirect("/portal/login");
+/** Public operational entry point. Authentication remains on the existing role-specific routes. */
+export default function PortalIndexPage() {
+  return <PortalLanding />;
 }

--- a/digital-cathedral/app/portal/portal-landing.tsx
+++ b/digital-cathedral/app/portal/portal-landing.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export function PortalLanding() {
+  return <main className="relative min-h-screen overflow-hidden bg-[#171714] px-5 text-[#f7f0e3]">
+    <div className="absolute inset-0 opacity-70 [background:radial-gradient(circle_at_75%_20%,rgba(201,167,95,.2),transparent_28%),linear-gradient(120deg,#171714_45%,#25231e)]" />
+    <div className="relative mx-auto flex min-h-screen max-w-6xl flex-col">
+      <header className="flex items-center justify-between border-b border-white/10 py-6"><div className="flex items-center gap-3"><span className="grid h-10 w-10 place-items-center rounded-full border border-[#c9a75f]/50 font-serif text-xl text-[#d5b972]">V</span><div><strong className="block text-sm">Valor Legacies</strong><span className="text-[10px] uppercase tracking-[.24em] text-[#c9a75f]">Operations</span></div></div><Link href="/developers" className="text-sm text-[#d8d0c3] hover:text-white">Developer resources →</Link></header>
+      <section className="grid flex-1 items-center gap-12 py-16 lg:grid-cols-[1.15fr_.85fr]">
+        <div><p className="mb-5 text-xs font-semibold uppercase tracking-[.3em] text-[#c9a75f]">Secure operational workspace</p><h1 className="max-w-4xl font-serif text-5xl font-light leading-[1.04] sm:text-6xl lg:text-7xl">Valor Legacies<br/><span className="text-[#d5b972]">Agent &amp; Admin Portal</span></h1><p className="mt-7 max-w-2xl text-base leading-7 text-[#c9c1b4] sm:text-lg">Manage leads, track performance, access resources, and support the operational side of Valor Legacies.</p><div className="mt-9 flex flex-wrap gap-3"><Link href="/portal/login" className="rounded-full bg-[#c9a75f] px-6 py-3 text-sm font-bold text-[#17140f] hover:bg-[#d8bb78]">Agent Login</Link><Link href="/admin/login" className="rounded-full border border-white/20 px-6 py-3 text-sm font-semibold hover:border-[#c9a75f]">Admin Login</Link><Link href="/developers" className="rounded-full border border-white/20 px-6 py-3 text-sm font-semibold hover:border-[#c9a75f]">Developer Portal</Link></div></div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1"><PortalFeature number="01" title="Move at lead speed" text="Keep priority work, follow-ups, and performance signals visible."/><PortalFeature number="02" title="Operate with confidence" text="Role-based access keeps agent, admin, and developer work focused."/><PortalFeature number="03" title="Protect every interaction" text="Compliance, consent, and operational accountability stay close to the work."/></div>
+      </section>
+      <footer className="border-t border-white/10 py-6 text-sm text-[#aaa296]">Looking for life insurance guidance? <a href="https://valorlegacies.com" className="font-semibold text-[#d5b972] hover:text-white">Visit valorlegacies.com</a></footer>
+    </div>
+  </main>;
+}
+
+function PortalFeature({ number, title, text }: { number: string; title: string; text: string }) {
+  return <div className="rounded-2xl border border-white/10 bg-white/[.035] p-5 backdrop-blur"><span className="text-xs tracking-[.2em] text-[#c9a75f]">{number}</span><h2 className="mt-3 font-serif text-xl">{title}</h2><p className="mt-2 text-sm leading-6 text-[#aaa296]">{text}</p></div>;
+}

--- a/digital-cathedral/middleware.ts
+++ b/digital-cathedral/middleware.ts
@@ -118,6 +118,7 @@ const CONSUMER_TO_PORTAL_REDIRECTS: Record<string, string> = {
 /** Routes that must only be served on the portal domain. */
 const PORTAL_ONLY_PREFIXES = [
   "/admin",
+  "/agent",
   "/portal",
   "/developers",
   "/api/admin",
@@ -319,6 +320,7 @@ export async function middleware(request: NextRequest) {
       pathname === "/" ||
       pathname === "/portal" ||
       pathname.startsWith("/portal/") ||
+      pathname.startsWith("/agent/") ||
       pathname.startsWith("/admin") ||
       pathname.startsWith("/developers") ||
       pathname.startsWith("/api/") ||
@@ -390,6 +392,15 @@ export async function middleware(request: NextRequest) {
     if (!(await hasAdminSession(request))) {
       const loginUrl = new URL("/admin/login", request.url);
       return NextResponse.redirect(loginUrl);
+    }
+  }
+
+  // Agent pages require an unexpired portal session at the route boundary.
+  // API handlers continue to verify the HMAC and ownership server-side.
+  if (pathname.startsWith("/agent")) {
+    const portalSession = request.cookies.get("__portal_session")?.value;
+    if (!portalSession || !isSessionLikelyValid(portalSession)) {
+      return NextResponse.redirect(new URL("/portal/login", request.url));
     }
   }
 


### PR DESCRIPTION
### Motivation
- Provide a clear public entry for the operational portal and begin Phase 1 of a role-based operational UX for agents, admins, and developers on `valorlegacies.xyz` while keeping the consumer site (`valorlegacies.com`) unchanged. 
- Give operators fast, premium-feeling dashboard shells that surface the most important KPIs and workflows (speed-to-lead, lead flow, revenue, compliance) without yet changing backend ingestion or billing logic. 
- Establish a reusable portal layout and navigation so future phases can iterate on lead management, marketplace purchase flows, and compliance panels with minimal layout work.

### Description
- Added a reusable portal shell component and UI primitives in `digital-cathedral/app/components/portal-shell.tsx` that implement role-scoped navigation, a sidebar, KPI `MetricCard`, `Panel` components, and logout handling. 
- Introduced a public operational landing page at `/portal` via `digital-cathedral/app/portal/portal-landing.tsx` and replaced the previous redirect behavior in `digital-cathedral/app/portal/page.tsx` to render that landing. 
- Implemented admin and agent dashboard shells at `digital-cathedral/app/admin/dashboard/page.tsx` (`/admin/dashboard`) and `digital-cathedral/app/agent/dashboard/page.tsx` (`/agent/dashboard`) that show KPI card placeholders, urgent-attention panels, lead-priority lists, quick actions, pipeline view, and strong empty states. 
- Updated routing/middleware in `digital-cathedral/middleware.ts` to classify portal/agent routes correctly and add a route-bound quick check for the portal session on `/agent/*` while preserving server-side HMAC/ownership checks in the APIs; no consumer-facing pages on `.com` were moved into the portal. 
- Files added/modified: `digital-cathedral/app/components/portal-shell.tsx`, `digital-cathedral/app/portal/portal-landing.tsx`, `digital-cathedral/app/portal/page.tsx` (updated), `digital-cathedral/app/admin/dashboard/page.tsx`, `digital-cathedral/app/agent/dashboard/page.tsx`, and `digital-cathedral/middleware.ts` (updated). 
- Existing functionality preserved: authentication flows, `api/*` lead endpoints, marketplace and purchase handlers, billing integrations, database adapters, and lead submission logic remain unchanged and continue to be the authoritative backend surfaces. 
- Backend fields/aggregates to provide in later phases (surfaced as placeholders rather than faked in UI): lead assignment status and assignee, first-contact timestamps (speed-to-lead), follow-up task items, appointment/calendar integration, agent credit balance, daily/monthly purchase and revenue rollups, refunds/chargebacks, compliance alert rollups (consent gaps, DNC/TCPA flags), dispute status, and outcome/ROI tracking. 

### Testing
- Ran unit and integration tests with `npm test` in the workspace and the `digital-cathedral` package, and all tests passed (428 tests, 0 failures). 
- Ran TypeScript checks with `npm run typecheck` and the project typecheck completed with no errors. 
- Ran repository audits and preflight checks (`node src/tools/goggles.js` and `node src/cli.js audit check` on changed files) and received audit outputs (no blocking failures for the changed files). 
- Build and browser-driven snapshot attempts encountered environment/network limitations: `npm run build` failed to patch a missing lockfile metadata due to registry/network reachability, and `npx playwright install` failed to download browsers (HTTP 403), so headless screenshot verification could not be produced in this environment; these are environmental failures rather than code regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81d42dd8c88333b8a525b75578210c)