### PR TITLE
Close portal-domain admin-preview loophole (nothing customer-facing on .xyz, ever)

### DIFF
--- a/digital-cathedral/middleware.ts
+++ b/digital-cathedral/middleware.ts
@@ -327,16 +327,18 @@ export async function middleware(request: NextRequest) {
       pathname.startsWith("/_next") ||
       pathname.startsWith("/.well-known") ||
       pathname.includes(".");
-    if (pathname === "/" && !(await hasAdminSession(request))) {
+    if (pathname === "/") {
       const portalHome = new URL("/portal", request.url);
       return NextResponse.redirect(portalHome, 301);
     }
-    // A logged-in admin can roam the full public site on the portal host
-    // (About, FAQ, the marketing home, etc.) instead of being bounced to
-    // /admin — "navigate the full website as admin". Everyone else is sent to
-    // the operator surface, keeping the public/operator split intact for
-    // non-admins and crawlers.
-    if (!isPortalRoute && !(await hasAdminSession(request))) {
+    // Domain isolation is non-negotiable: nothing customer-facing renders on
+    // the portal host, ever. Any non-portal path (About, FAQ, the marketing
+    // home, etc.) is bounced to the operator surface unconditionally —
+    // there is no admin-preview exception. A logged-in admin who wants to see
+    // the public site views it on the primary (.com) host; the portal (.xyz)
+    // host only ever serves operator surfaces, for every visitor including
+    // authenticated admins and crawlers.
+    if (!isPortalRoute) {
       const adminUrl = new URL("/admin", request.url);
       return NextResponse.redirect(adminUrl, 301);
     }


### PR DESCRIPTION
## Summary

Removes the admin-preview loophole in `digital-cathedral/middleware.ts` that let the portal (`.xyz`) host behave like a public site under the wrong conditions.

Both portal-domain redirects were gated on `!hasAdminSession(request)`, so a **logged-in admin** could roam the full public/consumer surface on the portal host — the marketing home, About, FAQ, etc. That is exactly the "customer-facing content rendering on `.xyz`" that domain isolation is meant to prevent.

## Change

Drop the `hasAdminSession` guards on the two portal-domain redirects so the rule is unconditional:

- `"/"` on the portal host **always** `301`s to `/portal`
- any **non-portal** path **always** `301`s to `/admin` (the operator surface)

…for every visitor, authenticated admins included. Admins who want to view the public site use the primary (`.com`) host. The portal (`.xyz`) host now only ever serves operator surfaces (`/portal`, `/agent`, `/admin`, `/developers`, APIs, static assets).

`hasAdminSession` is retained — it is still used for `/admin` route protection.

## Validation

- `tsc --noEmit` — clean
- `npm test` — 446/446 pass
- `cathedral-diagnostic.js` (goggles) — 0 findings on `middleware.ts` (tree-wide count unchanged from baseline; only one file touched)

The diff is a single-file, ~4-line logic change plus an explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ka23gxRerQQpT97wWFuZDJ)_